### PR TITLE
feat: add wechat-codex-start launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ wechat-codex
 
 如果你第一次使用本项目，建议优先从 `codex` 模式开始。当前仓库中，`codex` 是实现最完整、会话一致性与本地/远程衔接能力最完善的适配器路径。
 
+如果你更希望用**单命令入口**快速启动，也可以直接使用：
+
+```bash
+wechat-codex-start
+```
+
+它会：
+
+- 复用当前目录已存在的 bridge
+- 或自动结束其他目录的旧 bridge，并在当前目录后台启动新的 `wechat-bridge-codex`
+- 等待本地 endpoint 就绪
+- 然后自动进入 `wechat-codex`
+
 ### 5. 启动其他模式（暂待完善）
 
 `claude`：
@@ -186,6 +199,7 @@ wechat-bridge-shell
 ```bash
 wechat-bridge-codex
 wechat-codex
+wechat-codex-start
 wechat-bridge-claude
 wechat-bridge-shell
 ```
@@ -196,11 +210,33 @@ wechat-bridge-shell
 bun run setup
 bun run bridge:codex
 bun run codex:panel
+bun run codex:start
 bun run bridge:claude
 bun run bridge:shell
 bun run bridge:bun -- --adapter codex
 bun run test
 ```
+
+### Windows 右键脚本（仓库内版本）
+
+仓库内提供了一组便于维护的 Windows 右键菜单脚本，位置如下：
+
+```text
+windows-context-menu/
+```
+
+当前提供：
+
+- `安装Terminal→wechat-codex-start右键.py`
+- `卸载Terminal→wechat-codex-start右键.py`
+
+这组脚本会：
+
+- 在资源管理器目录背景或文件夹右键中添加入口
+- 打开 Windows Terminal
+- 在当前目录直接执行 `wechat-codex-start`
+
+也就是说，右键菜单本身不再重复实现 bridge / panel 编排逻辑，而是统一复用项目内的单命令启动器。
 
 ### Bridge CLI 参数
 
@@ -234,6 +270,18 @@ wechat-codex --cwd D:\work\my-project
 
 - `--cwd <path>`：显式连接该目录对应的 bridge endpoint
 
+### `wechat-codex-start` 参数
+
+```bash
+wechat-codex-start --cwd D:\work\my-project
+```
+
+支持参数：
+
+- `--cwd <path>`：指定工作目录
+- `--profile <name-or-path>`：传递给 bridge 适配器
+- `--timeout-ms <ms>`：等待 bridge endpoint 的最长时间
+
 ## 微信侧支持的指令
 
 | 指令 | 说明 |
@@ -256,6 +304,8 @@ wechat-codex --cwd D:\work\my-project
 - `wechat-codex` 负责本地可见 Codex 面板
 
 这种结构的目的是将微信桥接与本地可见面板分离，从而尽可能保留本地终端的原生交互。
+
+如果你只是想快速进入工作状态，也可以用 `wechat-codex-start` 作为单命令启动器；它不会替代双终端结构本身，只是把“先起 bridge、再起 panel”的步骤封装起来。
 
 ### 线程规则
 
@@ -372,6 +422,12 @@ Codex 的正常会话历史仍由 Codex 自身维护，默认保存在：
 
 1. 先在目标目录启动 `wechat-bridge-codex`
 2. 再在同一目录启动 `wechat-codex`
+
+或者直接：
+
+```bash
+wechat-codex-start
+```
 
 ### 2. 全局命令不存在
 

--- a/bin/wechat-codex-start.mjs
+++ b/bin/wechat-codex-start.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runTsEntry } from "./_run-entry.mjs";
+
+runTsEntry("codex-start.ts");

--- a/codex-start.test.ts
+++ b/codex-start.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  isSameWorkspaceCwd,
+  normalizeComparablePath,
+  parseCliArgs,
+} from "./codex-start.ts";
+
+describe("codex-start helpers", () => {
+  test("parseCliArgs uses current working directory by default", () => {
+    const options = parseCliArgs([]);
+    expect(options.cwd).toBe(process.cwd());
+    expect(options.timeoutMs).toBe(15000);
+  });
+
+  test("parseCliArgs parses cwd, profile, and timeout", () => {
+    const options = parseCliArgs([
+      "--cwd",
+      "./tmp/project",
+      "--profile",
+      "work",
+      "--timeout-ms",
+      "25000",
+    ]);
+
+    expect(options.cwd).toBe(path.resolve("./tmp/project"));
+    expect(options.profile).toBe("work");
+    expect(options.timeoutMs).toBe(25000);
+  });
+
+  test("normalizeComparablePath is stable for the same logical cwd", () => {
+    const first = normalizeComparablePath(".");
+    const second = normalizeComparablePath(process.cwd());
+    expect(first).toBe(second);
+  });
+
+  test("isSameWorkspaceCwd matches equivalent directory paths", () => {
+    expect(isSameWorkspaceCwd(".", process.cwd())).toBe(true);
+  });
+});

--- a/codex-start.ts
+++ b/codex-start.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  BRIDGE_LOCK_FILE,
+  BRIDGE_LOG_FILE,
+  CREDENTIALS_FILE,
+  migrateLegacyChannelFiles,
+} from "./channel-config.ts";
+import {
+  clearCodexPanelEndpoint,
+  readCodexPanelEndpoint,
+  type CodexPanelEndpoint,
+} from "./codex-panel-link.ts";
+
+type CodexStartCliOptions = {
+  cwd: string;
+  profile?: string;
+  timeoutMs: number;
+};
+
+type BridgeLockPayload = {
+  pid: number;
+  instanceId: string;
+  adapter: string;
+  command: string;
+  cwd: string;
+  startedAt: string;
+};
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_WAIT_TIMEOUT_MS = 15_000;
+
+function log(message: string): void {
+  process.stderr.write(`[codex-start] ${message}\n`);
+}
+
+export function normalizeComparablePath(cwd: string): string {
+  const normalized = path.resolve(cwd);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+export function isSameWorkspaceCwd(left: string, right: string): boolean {
+  return normalizeComparablePath(left) === normalizeComparablePath(right);
+}
+
+export function parseCliArgs(argv: string[]): CodexStartCliOptions {
+  let cwd = process.cwd();
+  let profile: string | undefined;
+  let timeoutMs = DEFAULT_WAIT_TIMEOUT_MS;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        [
+          "Usage: wechat-codex-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>]",
+          "",
+          "Starts or reuses the bridge for the current directory, waits for the local endpoint, then opens the visible Codex panel.",
+          "",
+        ].join("\n"),
+      );
+      process.exit(0);
+    }
+
+    if (arg === "--cwd") {
+      if (!next) {
+        throw new Error("--cwd requires a value");
+      }
+      cwd = path.resolve(next);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--profile") {
+      if (!next) {
+        throw new Error("--profile requires a value");
+      }
+      profile = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--timeout-ms") {
+      if (!next) {
+        throw new Error("--timeout-ms requires a value");
+      }
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed < 1000) {
+        throw new Error("--timeout-ms must be a number >= 1000");
+      }
+      timeoutMs = Math.trunc(parsed);
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { cwd, profile, timeoutMs };
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return !isPidAlive(pid);
+}
+
+async function stopExistingBridge(lock: BridgeLockPayload): Promise<void> {
+  const { pid, cwd } = lock;
+  log(`Stopping existing bridge for ${cwd} (pid=${pid})...`);
+
+  try {
+    process.kill(pid);
+  } catch (error) {
+    if (isPidAlive(pid)) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to stop existing bridge pid=${pid}: ${message}`);
+    }
+  }
+
+  if (!(await waitForProcessExit(pid, 10_000))) {
+    throw new Error(`Timed out waiting for existing bridge pid=${pid} to exit.`);
+  }
+
+  clearCodexPanelEndpoint(cwd);
+  log(`Cleared stale Codex endpoint for previous workspace ${cwd}.`);
+}
+
+function readBridgeLock(): BridgeLockPayload | null {
+  try {
+    if (!fs.existsSync(BRIDGE_LOCK_FILE)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(BRIDGE_LOCK_FILE, "utf8")) as BridgeLockPayload;
+  } catch {
+    return null;
+  }
+}
+
+async function isEndpointReachable(endpoint: CodexPanelEndpoint): Promise<boolean> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.connect({
+      host: "127.0.0.1",
+      port: endpoint.port,
+    });
+
+    let done = false;
+    const finish = (result: boolean) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(400);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function readUsableEndpoint(cwd: string): Promise<CodexPanelEndpoint | null> {
+  const endpoint = readCodexPanelEndpoint(cwd);
+  if (!endpoint) {
+    return null;
+  }
+
+  if (await isEndpointReachable(endpoint)) {
+    return endpoint;
+  }
+
+  clearCodexPanelEndpoint(cwd);
+  log(`Removed stale Codex endpoint for ${cwd}.`);
+  return null;
+}
+
+function startBridgeInBackground(options: CodexStartCliOptions): void {
+  const entryPath = path.join(MODULE_DIR, "wechat-bridge.ts");
+  const args = [
+    "--no-warnings",
+    "--experimental-strip-types",
+    entryPath,
+    "--adapter",
+    "codex",
+    "--cwd",
+    options.cwd,
+  ];
+
+  if (options.profile) {
+    args.push("--profile", options.profile);
+  }
+
+  const child = spawn(process.execPath, args, {
+    cwd: options.cwd,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  child.unref();
+}
+
+async function waitForEndpoint(cwd: string, timeoutMs: number): Promise<CodexPanelEndpoint> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const endpoint = await readUsableEndpoint(cwd);
+    if (endpoint) {
+      return endpoint;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Timed out waiting for the Codex bridge endpoint for ${cwd}. Check ${BRIDGE_LOG_FILE}.`,
+  );
+}
+
+async function ensureBridgeReady(options: CodexStartCliOptions): Promise<void> {
+  const existingEndpoint = await readUsableEndpoint(options.cwd);
+  if (existingEndpoint) {
+    log(`Reusing running bridge for ${options.cwd}.`);
+    return;
+  }
+
+  const lock = readBridgeLock();
+  if (lock && isPidAlive(lock.pid)) {
+    if (!isSameWorkspaceCwd(lock.cwd, options.cwd)) {
+      await stopExistingBridge(lock);
+      log(`Starting replacement bridge in background for ${options.cwd}...`);
+      startBridgeInBackground(options);
+      await waitForEndpoint(options.cwd, options.timeoutMs);
+      return;
+    }
+
+    log(`Found running bridge for ${options.cwd}. Waiting for endpoint...`);
+    await waitForEndpoint(options.cwd, options.timeoutMs);
+    return;
+  }
+
+  log(`Starting bridge in background for ${options.cwd}...`);
+  startBridgeInBackground(options);
+  await waitForEndpoint(options.cwd, options.timeoutMs);
+}
+
+async function runPanel(options: CodexStartCliOptions): Promise<number> {
+  const entryPath = path.join(MODULE_DIR, "codex-panel.ts");
+  const args = [
+    "--no-warnings",
+    "--experimental-strip-types",
+    entryPath,
+    "--cwd",
+    options.cwd,
+  ];
+
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", (error) => reject(error));
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  migrateLegacyChannelFiles(log);
+  const options = parseCliArgs(process.argv.slice(2));
+
+  if (!fs.existsSync(CREDENTIALS_FILE)) {
+    throw new Error(`Missing WeChat credentials. Run "bun run setup" first. (${CREDENTIALS_FILE})`);
+  }
+
+  await ensureBridgeReady(options);
+  const exitCode = await runPanel(options);
+  process.exit(exitCode);
+}
+
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main().catch((error) => {
+    log(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "wechat-bridge": "./bin/wechat-bridge.mjs",
     "wechat-bridge-codex": "./bin/wechat-bridge-codex.mjs",
     "wechat-codex": "./bin/wechat-codex.mjs",
+    "wechat-codex-start": "./bin/wechat-codex-start.mjs",
     "wechat-bridge-claude": "./bin/wechat-bridge-claude.mjs",
     "wechat-bridge-shell": "./bin/wechat-bridge-shell.mjs"
   },
@@ -18,6 +19,7 @@
     "bridge": "node --no-warnings --experimental-strip-types wechat-bridge.ts",
     "bridge:codex": "node --no-warnings --experimental-strip-types wechat-bridge.ts --adapter codex",
     "codex:panel": "node --no-warnings --experimental-strip-types codex-panel.ts",
+    "codex:start": "node --no-warnings --experimental-strip-types codex-start.ts",
     "bridge:claude": "node --no-warnings --experimental-strip-types wechat-bridge.ts --adapter claude",
     "bridge:shell": "node --no-warnings --experimental-strip-types wechat-bridge.ts --adapter shell",
     "bridge:bun": "bun wechat-bridge.ts",

--- a/windows-context-menu/卸载Terminal→wechat-codex-start右键.py
+++ b/windows-context-menu/卸载Terminal→wechat-codex-start右键.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WeChat Codex Start 右键菜单卸载脚本
+双击运行即可，会自动请求管理员权限
+"""
+
+import os
+import sys
+import ctypes
+import winreg
+
+
+REG_PATHS = [
+    r"Directory\Background\shell\WeChatCodexStartHere",
+    r"Directory\shell\WeChatCodexStartHere",
+]
+
+
+def is_admin():
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception:
+        return False
+
+
+def run_as_admin():
+    script = os.path.abspath(__file__)
+    ret = ctypes.windll.shell32.ShellExecuteW(
+        None, "runas", sys.executable, f'"{script}"', None, 1
+    )
+    if ret > 32:
+        sys.exit(0)
+    else:
+        print(f"✗ 无法提升权限 (错误码: {ret})")
+        input("\n按回车键退出...")
+        sys.exit(1)
+
+
+def delete_reg_tree(root, path):
+    try:
+        try:
+            key = winreg.OpenKeyEx(root, path, 0, winreg.KEY_READ)
+            subkeys = []
+            i = 0
+            while True:
+                try:
+                    subkeys.append(winreg.EnumKey(key, i))
+                    i += 1
+                except OSError:
+                    break
+            winreg.CloseKey(key)
+
+            for subkey in subkeys:
+                delete_reg_tree(root, path + "\\" + subkey)
+        except FileNotFoundError:
+            pass
+
+        winreg.DeleteKey(root, path)
+        return True
+    except FileNotFoundError:
+        return True
+    except Exception as e:
+        print(f"  删除失败 {path}: {e}")
+        return False
+
+
+def uninstall_menu():
+    success_count = 0
+    for reg_path in REG_PATHS:
+        print(f"\n删除菜单项: HKCR\\{reg_path}")
+        if delete_reg_tree(winreg.HKEY_CLASSES_ROOT, reg_path):
+            print("  [OK] 成功")
+            success_count += 1
+        else:
+            print("  [FAIL] 失败")
+    return success_count
+
+
+def main():
+    print("=" * 72)
+    print("  WeChat Codex Start 右键菜单卸载脚本")
+    print("=" * 72)
+    print()
+
+    if not is_admin():
+        print("需要管理员权限，正在请求提升...")
+        run_as_admin()
+        return
+
+    print("[OK] 已获得管理员权限")
+
+    success = uninstall_menu()
+
+    print()
+    print("=" * 72)
+    if success > 0:
+        print(f"  [OK] 卸载完成！已处理 {success} 个菜单项")
+    else:
+        print("  [WARN] 没有找到需要删除的菜单项")
+    print("=" * 72)
+
+    input("\n按回车键退出...")
+
+
+if __name__ == "__main__":
+    main()

--- a/windows-context-menu/安装Terminal→wechat-codex-start右键.py
+++ b/windows-context-menu/安装Terminal→wechat-codex-start右键.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WeChat Codex Start 右键菜单安装脚本
+
+效果：
+- 在文件夹空白处或文件夹上右键
+- 选择“在此处打开 WeChat Codex Start”
+- 自动打开 Windows Terminal
+- 在当前目录执行 wechat-codex-start
+
+说明：
+- wechat-codex-start 会自动处理 bridge 复用、切目录接管、等待 endpoint、进入 panel
+- 双击运行即可，会自动请求管理员权限
+"""
+
+import os
+import sys
+import ctypes
+import subprocess
+import shutil
+import winreg
+
+
+MENU_KEY = "WeChatCodexStartHere"
+MENU_TEXT = "在此处打开 WeChat Codex Start"
+CLI_COMMAND = "wechat-codex-start"
+
+
+def is_admin():
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception:
+        return False
+
+
+def run_as_admin():
+    script = os.path.abspath(__file__)
+    ret = ctypes.windll.shell32.ShellExecuteW(
+        None, "runas", sys.executable, f'"{script}"', None, 1
+    )
+    if ret > 32:
+        sys.exit(0)
+    else:
+        print(f"✗ 无法提升权限 (错误码: {ret})")
+        input("\n按回车键退出...")
+        sys.exit(1)
+
+
+def create_reg_key(root, path):
+    try:
+        return winreg.CreateKeyEx(root, path, 0, winreg.KEY_WRITE)
+    except Exception as e:
+        print(f"  创建键失败 {path}: {e}")
+        return None
+
+
+def set_reg_value(key, name, value, value_type=winreg.REG_SZ):
+    try:
+        winreg.SetValueEx(key, name, 0, value_type, value)
+        return True
+    except Exception as e:
+        print(f"  设置值失败 {name}: {e}")
+        return False
+
+
+def find_pwsh():
+    candidates = [
+        r"C:\Windows\System32\WindowsPowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files (x86)\PowerShell\7\pwsh.exe",
+        os.path.expandvars(r"%LOCALAPPDATA%\Microsoft\PowerShell\pwsh.exe"),
+    ]
+
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+
+    try:
+        result = subprocess.run(["where", "pwsh"], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            return result.stdout.strip().splitlines()[0]
+    except Exception:
+        pass
+
+    return None
+
+
+def find_wt():
+    candidates = [
+        shutil.which("wt"),
+        os.path.expandvars(r"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe"),
+        r"C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_8wekyb3d8bbwe\wt.exe",
+    ]
+
+    for path in candidates:
+        if path and os.path.exists(path):
+            return path
+
+    return None
+
+
+def find_icon_in_folder(folder_path: str):
+    if not os.path.isdir(folder_path):
+        return None
+
+    for file in os.listdir(folder_path):
+        if file.lower().endswith(".ico"):
+            return os.path.join(folder_path, file)
+
+    return None
+
+
+def command_exists(command_name: str) -> bool:
+    return shutil.which(command_name) is not None
+
+
+def build_terminal_command(wt_path: str, pwsh_path: str | None = None):
+    if pwsh_path:
+        command = (
+            f'"{wt_path}" new-tab -d "%V" --title "WeChat Codex Start" '
+            f'"{pwsh_path}" -NoExit -Command "{CLI_COMMAND}"'
+        )
+        icon_path = find_icon_in_folder(os.path.dirname(pwsh_path)) or wt_path
+    else:
+        command = f'"{wt_path}" new-tab -d "%V" --title "WeChat Codex Start" {CLI_COMMAND}'
+        icon_path = wt_path
+
+    return command, icon_path
+
+
+def install_menu(wt_path: str, pwsh_path: str | None = None):
+    command, icon_path = build_terminal_command(wt_path, pwsh_path)
+    menu_items = [
+        ("Directory\\Background\\shell\\" + MENU_KEY, MENU_TEXT),
+        ("Directory\\shell\\" + MENU_KEY, MENU_TEXT),
+    ]
+
+    success_count = 0
+
+    print(f"\n最终命令：{command}")
+    print("\n[说明] 此菜单会直接调用 wechat-codex-start。")
+    print("[说明] wechat-codex-start 会自动处理 bridge 启停、目录切换与 panel 连接。")
+
+    if not command_exists(CLI_COMMAND):
+        print(f"[WARN] 当前 PATH 中未找到命令：{CLI_COMMAND}")
+        print("       请确认已执行 npm link 或 npm install -g .")
+
+    for reg_path, menu_text in menu_items:
+        print(f"\n添加菜单项: {menu_text}")
+        print(f"  注册表路径: HKCR\\{reg_path}")
+
+        try:
+            key = create_reg_key(winreg.HKEY_CLASSES_ROOT, reg_path)
+            if key is None:
+                continue
+
+            set_reg_value(key, "", menu_text)
+            set_reg_value(key, "Icon", icon_path)
+            winreg.CloseKey(key)
+
+            cmd_key = create_reg_key(winreg.HKEY_CLASSES_ROOT, reg_path + r"\command")
+            if cmd_key is None:
+                continue
+
+            set_reg_value(cmd_key, "", command)
+            winreg.CloseKey(cmd_key)
+
+            print("  [OK] 成功")
+            success_count += 1
+        except Exception as e:
+            print(f"  [FAIL] 失败: {e}")
+
+    return success_count
+
+
+def main():
+    print("=" * 72)
+    print("  WeChat Codex Start 右键菜单安装脚本")
+    print("=" * 72)
+    print()
+
+    if not is_admin():
+        print("需要管理员权限，正在请求提升...")
+        run_as_admin()
+        return
+
+    print("[OK] 已获得管理员权限")
+
+    wt_path = find_wt()
+    if not wt_path:
+        print("\n[FAIL] 找不到 wt.exe，请先安装 Windows Terminal，或确认 wt 已加入 PATH。")
+        input("\n按回车键退出...")
+        sys.exit(1)
+
+    print(f"\nwt.exe 路径: {wt_path}")
+
+    pwsh_path = find_pwsh()
+    if pwsh_path:
+        print(f"pwsh.exe 路径: {pwsh_path}")
+    else:
+        print("[WARN] 未找到 pwsh.exe，将使用默认 shell")
+
+    success = install_menu(wt_path, pwsh_path)
+
+    print()
+    print("=" * 72)
+    if success > 0:
+        print(f"  [OK] 安装完成！已添加 {success} 个菜单项")
+        print("  右键后可直接启动 WeChat Codex Start。")
+    else:
+        print("  [FAIL] 安装失败")
+    print("=" * 72)
+
+    input("\n按回车键退出...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更内容
- 新增 `wechat-codex-start` 单命令启动器，统一处理 bridge 复用、切目录接管、等待 endpoint、再进入 panel
- 更新 `README.md`，补充单命令启动方式与仓库内 Windows 右键脚本说明
- 新增仓库内 `windows-context-menu` 脚本，直接调用 `wechat-codex-start`
- 补充 `codex-start` 相关测试与 `package.json` 命令入口

## 验证
- `bun test`
- `node --no-warnings --experimental-strip-types codex-start.ts --help`
