### PR TITLE
feat: add wechat-codex-start entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ wechat-codex
 
 如果你第一次使用本项目，建议优先从 `codex` 模式开始。当前仓库中，`codex` 是实现最完整、会话一致性与本地/远程衔接能力最完善的适配器路径。
 
+如果你更希望用**单命令入口**快速启动，也可以直接使用：
+
+```bash
+wechat-codex-start
+```
+
+它会自动完成以下动作：
+
+1. 复用当前目录已运行的 `wechat-bridge-codex`
+2. 如果 bridge 正在服务其他目录，则停止旧 bridge 并切换到当前目录
+3. 等待当前目录对应的本地 companion endpoint 就绪
+4. 打开可见的 `wechat-codex` 会话
+
 ### 5. 启动 Claude Code （不走Channels）
 
 与 Codex 类似的，
@@ -163,6 +176,7 @@ wechat-claude
 ```bash
 wechat-bridge-codex
 wechat-codex
+wechat-codex-start
 wechat-bridge-claude
 wechat-claude
 wechat-bridge-shell
@@ -174,6 +188,7 @@ wechat-bridge-shell
 bun run setup
 bun run bridge:codex
 bun run codex:panel
+bun run codex:start
 bun run bridge:claude
 bun run claude:companion
 bun run bridge:shell
@@ -202,6 +217,21 @@ wechat-bridge-shell --cmd pwsh.exe
 - `--cwd <path>`：指定工作目录
 - `--cmd <executable>`：覆盖默认命令
 - `--profile <name-or-path>`：向适配器传入 profile
+
+### `wechat-codex-start` 参数
+
+示例：
+
+```bash
+wechat-codex-start --cwd D:\work\my-project
+wechat-codex-start --profile work
+```
+
+支持参数：
+
+- `--cwd <path>`：显式指定 bridge / companion 对应的工作目录
+- `--profile <name-or-path>`：转发给后台启动的 `wechat-bridge-codex`
+- `--timeout-ms <ms>`：等待当前目录 endpoint 的最长时间，默认 `15000`
 
 ## 微信侧支持的指令
 
@@ -267,6 +297,12 @@ wechat-bridge-shell --cmd pwsh.exe
 
 1. 先在目标目录启动 `wechat-bridge-codex`
 2. 再在同一目录启动 `wechat-codex`
+
+如果你不想手动分两个终端，也可以直接执行：
+
+```bash
+wechat-codex-start
+```
 
 ### 2. 全局命令不存在
 

--- a/bin/wechat-codex-start.mjs
+++ b/bin/wechat-codex-start.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runTsEntry } from "./_run-entry.mjs";
+
+runTsEntry("src/companion/local-companion-start.ts");

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "wechat-bridge": "./bin/wechat-bridge.mjs",
     "wechat-bridge-codex": "./bin/wechat-bridge-codex.mjs",
     "wechat-codex": "./bin/wechat-codex.mjs",
+    "wechat-codex-start": "./bin/wechat-codex-start.mjs",
     "wechat-claude": "./bin/wechat-claude.mjs",
     "wechat-bridge-claude": "./bin/wechat-bridge-claude.mjs",
     "wechat-bridge-shell": "./bin/wechat-bridge-shell.mjs"
@@ -19,6 +20,7 @@
     "bridge": "node --no-warnings --experimental-strip-types src/bridge/wechat-bridge.ts",
     "bridge:codex": "node --no-warnings --experimental-strip-types src/bridge/wechat-bridge.ts --adapter codex",
     "codex:panel": "node --no-warnings --experimental-strip-types src/companion/local-companion.ts --adapter codex",
+    "codex:start": "node --no-warnings --experimental-strip-types src/companion/local-companion-start.ts",
     "claude:companion": "node --no-warnings --experimental-strip-types src/companion/local-companion.ts --adapter claude",
     "bridge:claude": "node --no-warnings --experimental-strip-types src/bridge/wechat-bridge.ts --adapter claude",
     "bridge:shell": "node --no-warnings --experimental-strip-types src/bridge/wechat-bridge.ts --adapter shell",

--- a/src/companion/local-companion-start.test.ts
+++ b/src/companion/local-companion-start.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  isSameWorkspaceCwd,
+  normalizeComparablePath,
+  parseCliArgs,
+} from "./local-companion-start.ts";
+
+describe("local-companion-start helpers", () => {
+  test("parseCliArgs uses current working directory by default", () => {
+    const options = parseCliArgs([]);
+    expect(options.cwd).toBe(process.cwd());
+    expect(options.timeoutMs).toBe(15000);
+  });
+
+  test("parseCliArgs parses cwd, profile, and timeout", () => {
+    const options = parseCliArgs([
+      "--cwd",
+      "./tmp/project",
+      "--profile",
+      "work",
+      "--timeout-ms",
+      "25000",
+    ]);
+
+    expect(options.cwd).toBe(path.resolve("./tmp/project"));
+    expect(options.profile).toBe("work");
+    expect(options.timeoutMs).toBe(25000);
+  });
+
+  test("normalizeComparablePath is stable for the same logical cwd", () => {
+    const first = normalizeComparablePath(".");
+    const second = normalizeComparablePath(process.cwd());
+    expect(first).toBe(second);
+  });
+
+  test("isSameWorkspaceCwd matches equivalent directory paths", () => {
+    expect(isSameWorkspaceCwd(".", process.cwd())).toBe(true);
+  });
+});

--- a/src/companion/local-companion-start.ts
+++ b/src/companion/local-companion-start.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  BRIDGE_LOCK_FILE,
+  BRIDGE_LOG_FILE,
+  CREDENTIALS_FILE,
+  migrateLegacyChannelFiles,
+} from "../wechat/channel-config.ts";
+import {
+  clearLocalCompanionEndpoint,
+  readLocalCompanionEndpoint,
+  type LocalCompanionEndpoint,
+} from "./local-companion-link.ts";
+
+type LocalCompanionStartCliOptions = {
+  cwd: string;
+  profile?: string;
+  timeoutMs: number;
+};
+
+type BridgeLockPayload = {
+  pid: number;
+  instanceId: string;
+  adapter: string;
+  command: string;
+  cwd: string;
+  startedAt: string;
+};
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_WAIT_TIMEOUT_MS = 15_000;
+
+function log(message: string): void {
+  process.stderr.write(`[codex-start] ${message}\n`);
+}
+
+export function normalizeComparablePath(cwd: string): string {
+  const normalized = path.resolve(cwd);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+export function isSameWorkspaceCwd(left: string, right: string): boolean {
+  return normalizeComparablePath(left) === normalizeComparablePath(right);
+}
+
+export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
+  let cwd = process.cwd();
+  let profile: string | undefined;
+  let timeoutMs = DEFAULT_WAIT_TIMEOUT_MS;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        [
+          "Usage: wechat-codex-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>]",
+          "",
+          "Starts or reuses the Codex bridge for the current directory, waits for the local companion endpoint, then opens the visible Codex companion.",
+          "",
+        ].join("\n"),
+      );
+      process.exit(0);
+    }
+
+    if (arg === "--cwd") {
+      if (!next) {
+        throw new Error("--cwd requires a value");
+      }
+      cwd = path.resolve(next);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--profile") {
+      if (!next) {
+        throw new Error("--profile requires a value");
+      }
+      profile = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--timeout-ms") {
+      if (!next) {
+        throw new Error("--timeout-ms requires a value");
+      }
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed < 1000) {
+        throw new Error("--timeout-ms must be a number >= 1000");
+      }
+      timeoutMs = Math.trunc(parsed);
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { cwd, profile, timeoutMs };
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return !isPidAlive(pid);
+}
+
+async function stopExistingBridge(lock: BridgeLockPayload): Promise<void> {
+  const { pid, cwd } = lock;
+  log(`Stopping existing bridge for ${cwd} (pid=${pid})...`);
+
+  try {
+    process.kill(pid);
+  } catch (error) {
+    if (isPidAlive(pid)) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to stop existing bridge pid=${pid}: ${message}`);
+    }
+  }
+
+  if (!(await waitForProcessExit(pid, 10_000))) {
+    throw new Error(`Timed out waiting for existing bridge pid=${pid} to exit.`);
+  }
+
+  clearLocalCompanionEndpoint(cwd);
+  log(`Cleared stale local companion endpoint for previous workspace ${cwd}.`);
+}
+
+function readBridgeLock(): BridgeLockPayload | null {
+  try {
+    if (!fs.existsSync(BRIDGE_LOCK_FILE)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(BRIDGE_LOCK_FILE, "utf8")) as BridgeLockPayload;
+  } catch {
+    return null;
+  }
+}
+
+async function isEndpointReachable(endpoint: LocalCompanionEndpoint): Promise<boolean> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.connect({
+      host: "127.0.0.1",
+      port: endpoint.port,
+    });
+
+    let done = false;
+    const finish = (result: boolean) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(400);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function readUsableEndpoint(cwd: string): Promise<LocalCompanionEndpoint | null> {
+  const endpoint = readLocalCompanionEndpoint(cwd);
+  if (!endpoint || endpoint.kind !== "codex") {
+    return null;
+  }
+
+  if (await isEndpointReachable(endpoint)) {
+    return endpoint;
+  }
+
+  clearLocalCompanionEndpoint(cwd);
+  log(`Removed stale local companion endpoint for ${cwd}.`);
+  return null;
+}
+
+function startBridgeInBackground(options: LocalCompanionStartCliOptions): void {
+  const entryPath = path.resolve(MODULE_DIR, "..", "bridge", "wechat-bridge.ts");
+  const args = [
+    "--no-warnings",
+    "--experimental-strip-types",
+    entryPath,
+    "--adapter",
+    "codex",
+    "--cwd",
+    options.cwd,
+  ];
+
+  if (options.profile) {
+    args.push("--profile", options.profile);
+  }
+
+  const child = spawn(process.execPath, args, {
+    cwd: options.cwd,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  child.unref();
+}
+
+async function waitForEndpoint(
+  cwd: string,
+  timeoutMs: number,
+): Promise<LocalCompanionEndpoint> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const endpoint = await readUsableEndpoint(cwd);
+    if (endpoint) {
+      return endpoint;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Timed out waiting for the Codex bridge endpoint for ${cwd}. Check ${BRIDGE_LOG_FILE}.`,
+  );
+}
+
+async function ensureBridgeReady(options: LocalCompanionStartCliOptions): Promise<void> {
+  const existingEndpoint = await readUsableEndpoint(options.cwd);
+  if (existingEndpoint) {
+    log(`Reusing running bridge for ${options.cwd}.`);
+    return;
+  }
+
+  const lock = readBridgeLock();
+  if (lock && isPidAlive(lock.pid)) {
+    if (!isSameWorkspaceCwd(lock.cwd, options.cwd)) {
+      await stopExistingBridge(lock);
+      log(`Starting replacement bridge in background for ${options.cwd}...`);
+      startBridgeInBackground(options);
+      await waitForEndpoint(options.cwd, options.timeoutMs);
+      return;
+    }
+
+    log(`Found running bridge for ${options.cwd}. Waiting for endpoint...`);
+    await waitForEndpoint(options.cwd, options.timeoutMs);
+    return;
+  }
+
+  log(`Starting bridge in background for ${options.cwd}...`);
+  startBridgeInBackground(options);
+  await waitForEndpoint(options.cwd, options.timeoutMs);
+}
+
+async function runCompanion(options: LocalCompanionStartCliOptions): Promise<number> {
+  const entryPath = path.resolve(MODULE_DIR, "local-companion.ts");
+  const args = [
+    "--no-warnings",
+    "--experimental-strip-types",
+    entryPath,
+    "--adapter",
+    "codex",
+    "--cwd",
+    options.cwd,
+  ];
+
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", (error) => reject(error));
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  migrateLegacyChannelFiles(log);
+  const options = parseCliArgs(process.argv.slice(2));
+
+  if (!fs.existsSync(CREDENTIALS_FILE)) {
+    throw new Error(`Missing WeChat credentials. Run "bun run setup" first. (${CREDENTIALS_FILE})`);
+  }
+
+  await ensureBridgeReady(options);
+  const exitCode = await runCompanion(options);
+  process.exit(exitCode);
+}
+
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main().catch((error) => {
+    log(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 变更内容
- 新增 `wechat-codex-start` 单命令入口，按最新项目结构迁移到 `src/companion/local-companion-start.ts`
- 启动器会自动复用当前目录 bridge，必要时切换工作区并等待 endpoint 后再启动可见 companion
- 补充对应测试、`package.json` 命令入口与 README 使用说明

## 说明
- 这次 PR 基于最新 `main` 重新整理，只保留核心启动器功能，尽量缩小改动范围，方便 review 和 merge
- 未包含旧分支中的 Windows 右键脚本等附加改动

## 验证
- `bun test`
- `node --no-warnings --experimental-strip-types src/companion/local-companion-start.ts --help`
