### PR TITLE
fix: auto-heal unhealthy wechat-codex-start bridges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ log.md
 tmp-codex-*.log
 plan/
 architecture/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ wechat-codex-start
 3. 等待当前目录对应的本地 companion endpoint 就绪
 4. 打开可见的 `wechat-codex` 会话
 
+`wechat-codex-start` 现在按**单活工作区切换器**工作：
+
+- 同一时间只有一个项目与微信对话
+- 在当前目录重复执行是幂等的
+- 如果当前目录已经有可见 companion 在运行，则不会重复打开第二个窗口
+- 在其他目录执行会显式切换活动工作区
+
 ### 5. 启动 Claude Code （不走Channels）
 
 与 Codex 类似的，
@@ -245,6 +252,12 @@ wechat-codex-start --profile work
 - `--profile <name-or-path>`：转发给后台启动的 `wechat-bridge-codex`
 - `--timeout-ms <ms>`：等待当前目录 endpoint 的最长时间，默认 `15000`
 
+行为说明：
+
+- 同目录重复执行：复用当前目录 bridge；如果 companion 已经在线，则直接提示当前工作区已激活，不会重复打开第二个 companion
+- 不同目录执行：会停止旧目录的临时 bridge，并切换到新的活动工作区
+- 关闭可见 companion 后，后台 `companion_bound` bridge 会一起退出
+
 ### `wechat-claude-start` 参数
 
 示例：
@@ -282,6 +295,12 @@ wechat-claude-start --profile work
 - 单 owner
 - 单 bridge
 - 单活动工作区
+
+对 `wechat-codex-start` / `wechat-claude-start` 来说，这意味着：
+
+- 它们是**单活工作区切换器**
+- 当前目录重复执行是幂等的
+- 其他目录重复执行会触发工作区切换，而不是并行多开
 
 ## 数据目录与状态文件
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ wechat-codex-start --profile work
 行为说明：
 
 - 同目录重复执行：复用当前目录 bridge；如果 companion 已经在线，则直接提示当前工作区已激活，不会重复打开第二个 companion
+- 同目录检测到 companion 已连接但 worker 状态异常（如 `stopped` / `error`）时：会自动回收旧 bridge 并重新启动
 - 不同目录执行：会停止旧目录的临时 bridge，并切换到新的活动工作区
 - 关闭可见 companion 后，后台 `companion_bound` bridge 会一起退出
 

--- a/src/bridge/bridge-adapters.core.ts
+++ b/src/bridge/bridge-adapters.core.ts
@@ -7,6 +7,7 @@ import {
   clearLocalCompanionEndpoint,
   clearLocalCompanionOccupancy,
   sendLocalCompanionMessage,
+  updateLocalCompanionHealth,
   updateLocalCompanionOccupancy,
   writeLocalCompanionEndpoint,
   type LocalCompanionCommand,
@@ -288,6 +289,11 @@ export class LocalCompanionProxyAdapter implements BridgeAdapter {
         return;
       case "state":
         if (this.endpoint) {
+          updateLocalCompanionHealth(
+            this.options.cwd,
+            buildCompanionHealthPatch(message.state, nowIso()),
+            this.endpoint.instanceId,
+          );
           const nextSessionId = getSharedSessionIdFromAdapterState(message.state);
           if (
             this.endpoint.sharedSessionId !== nextSessionId ||
@@ -410,6 +416,21 @@ export function shouldStopBridgeAfterCompanionDisconnect(
   lifecycle: BridgeLifecycleMode | undefined,
 ): boolean {
   return lifecycle === "companion_bound";
+}
+
+export function buildCompanionHealthPatch(
+  state: BridgeAdapterState,
+  timestamp: string,
+): {
+  companionStatus: BridgeAdapterState["status"];
+  companionLastStateAt: string;
+  companionWorkerPid?: number;
+} {
+  return {
+    companionStatus: state.status,
+    companionLastStateAt: timestamp,
+    companionWorkerPid: state.pid,
+  };
 }
 
 export abstract class AbstractPtyAdapter implements BridgeAdapter {

--- a/src/bridge/bridge-adapters.core.ts
+++ b/src/bridge/bridge-adapters.core.ts
@@ -5,7 +5,9 @@ import {
   attachLocalCompanionMessageListener,
   buildLocalCompanionToken,
   clearLocalCompanionEndpoint,
+  clearLocalCompanionOccupancy,
   sendLocalCompanionMessage,
+  updateLocalCompanionOccupancy,
   writeLocalCompanionEndpoint,
   type LocalCompanionCommand,
   type LocalCompanionEndpoint,
@@ -236,6 +238,14 @@ export class LocalCompanionProxyAdapter implements BridgeAdapter {
         authenticated = true;
         this.socket = socket;
         this.detachMessageListener = detachListener;
+        updateLocalCompanionOccupancy(
+          this.options.cwd,
+          {
+            companionPid: message.companionPid,
+            companionConnectedAt: nowIso(),
+          },
+          this.endpoint?.instanceId,
+        );
         sendLocalCompanionMessage(socket, { type: "hello_ack" });
         return;
       }
@@ -245,6 +255,7 @@ export class LocalCompanionProxyAdapter implements BridgeAdapter {
 
     socket.once("close", () => {
       if (this.socket === socket) {
+        clearLocalCompanionOccupancy(this.options.cwd, this.endpoint?.instanceId);
         this.detachPanelSocket();
         if (!this.shuttingDown) {
           if (shouldStopBridgeAfterCompanionDisconnect(this.options.lifecycle)) {

--- a/src/companion/local-companion-link.ts
+++ b/src/companion/local-companion-link.ts
@@ -10,6 +10,7 @@ import type {
   BridgeAdapterKind,
   BridgeAdapterState,
   BridgeEvent,
+  BridgeWorkerStatus,
 } from "../bridge/bridge-types.ts";
 
 export type LocalCompanionCommand =
@@ -37,6 +38,9 @@ export type LocalCompanionEndpoint = {
   transcriptPath?: string;
   companionPid?: number;
   companionConnectedAt?: string;
+  companionStatus?: BridgeWorkerStatus;
+  companionLastStateAt?: string;
+  companionWorkerPid?: number;
   startedAt: string;
 };
 
@@ -121,6 +125,12 @@ function normalizeEndpoint(value: unknown): LocalCompanionEndpoint | null {
     companionPid: typeof record.companionPid === "number" ? record.companionPid : undefined,
     companionConnectedAt:
       typeof record.companionConnectedAt === "string" ? record.companionConnectedAt : undefined,
+    companionStatus:
+      typeof record.companionStatus === "string" ? (record.companionStatus as BridgeWorkerStatus) : undefined,
+    companionLastStateAt:
+      typeof record.companionLastStateAt === "string" ? record.companionLastStateAt : undefined,
+    companionWorkerPid:
+      typeof record.companionWorkerPid === "number" ? record.companionWorkerPid : undefined,
     startedAt: record.startedAt,
   };
 }
@@ -190,9 +200,42 @@ export function clearLocalCompanionOccupancy(cwd: string, instanceId?: string): 
       ...endpoint,
       companionPid: undefined,
       companionConnectedAt: undefined,
+      companionStatus: undefined,
+      companionLastStateAt: undefined,
+      companionWorkerPid: undefined,
     };
 
     writeLocalCompanionEndpoint(nextEndpoint);
+  } catch {
+    // Best effort cleanup.
+  }
+}
+
+export function updateLocalCompanionHealth(
+  cwd: string,
+  patch: {
+    companionStatus?: BridgeWorkerStatus;
+    companionLastStateAt?: string;
+    companionWorkerPid?: number;
+  },
+  instanceId?: string,
+): void {
+  try {
+    const endpoint = readLocalCompanionEndpoint(cwd);
+    if (!endpoint) {
+      return;
+    }
+
+    if (instanceId && endpoint.instanceId !== instanceId) {
+      return;
+    }
+
+    writeLocalCompanionEndpoint({
+      ...endpoint,
+      companionStatus: patch.companionStatus,
+      companionLastStateAt: patch.companionLastStateAt,
+      companionWorkerPid: patch.companionWorkerPid,
+    });
   } catch {
     // Best effort cleanup.
   }

--- a/src/companion/local-companion-link.ts
+++ b/src/companion/local-companion-link.ts
@@ -35,6 +35,8 @@ export type LocalCompanionEndpoint = {
   sharedThreadId?: string;
   resumeConversationId?: string;
   transcriptPath?: string;
+  companionPid?: number;
+  companionConnectedAt?: string;
   startedAt: string;
 };
 
@@ -116,6 +118,9 @@ function normalizeEndpoint(value: unknown): LocalCompanionEndpoint | null {
       typeof record.resumeConversationId === "string" ? record.resumeConversationId : undefined,
     transcriptPath:
       typeof record.transcriptPath === "string" ? record.transcriptPath : undefined,
+    companionPid: typeof record.companionPid === "number" ? record.companionPid : undefined,
+    companionConnectedAt:
+      typeof record.companionConnectedAt === "string" ? record.companionConnectedAt : undefined,
     startedAt: record.startedAt,
   };
 }
@@ -165,6 +170,57 @@ export function clearLocalCompanionEndpoint(cwd: string, instanceId?: string): v
     if (!endpoint || endpoint.instanceId === instanceId) {
       fs.rmSync(endpointFile, { force: true });
     }
+  } catch {
+    // Best effort cleanup.
+  }
+}
+
+export function clearLocalCompanionOccupancy(cwd: string, instanceId?: string): void {
+  try {
+    const endpoint = readLocalCompanionEndpoint(cwd);
+    if (!endpoint) {
+      return;
+    }
+
+    if (instanceId && endpoint.instanceId !== instanceId) {
+      return;
+    }
+
+    const nextEndpoint: LocalCompanionEndpoint = {
+      ...endpoint,
+      companionPid: undefined,
+      companionConnectedAt: undefined,
+    };
+
+    writeLocalCompanionEndpoint(nextEndpoint);
+  } catch {
+    // Best effort cleanup.
+  }
+}
+
+export function updateLocalCompanionOccupancy(
+  cwd: string,
+  patch: {
+    companionPid?: number;
+    companionConnectedAt?: string;
+  },
+  instanceId?: string,
+): void {
+  try {
+    const endpoint = readLocalCompanionEndpoint(cwd);
+    if (!endpoint) {
+      return;
+    }
+
+    if (instanceId && endpoint.instanceId !== instanceId) {
+      return;
+    }
+
+    writeLocalCompanionEndpoint({
+      ...endpoint,
+      companionPid: patch.companionPid,
+      companionConnectedAt: patch.companionConnectedAt,
+    });
   } catch {
     // Best effort cleanup.
   }

--- a/src/companion/local-companion-start.ts
+++ b/src/companion/local-companion-start.ts
@@ -40,6 +40,7 @@ type EnsureBridgeReadyResult = {
 export type LocalCompanionLaunchDecision =
   | { kind: "already_active"; message: string }
   | { kind: "open_companion"; message: string }
+  | { kind: "restart_unhealthy"; message: string }
   | {
       kind: "switch_workspace";
       fromCwd: string;
@@ -89,6 +90,10 @@ export function formatSwitchFailureMessage(cwd: string): string {
   return `Failed to stop the previous workspace bridge. Switch canceled; current workspace remains ${cwd}.`;
 }
 
+export function formatRestartUnhealthyMessage(cwd: string): string {
+  return `Detected unhealthy companion state for ${cwd}. Restarting bridge...`;
+}
+
 export function decideLaunchAction(input: DecideLaunchActionInput): LocalCompanionLaunchDecision {
   const sameWorkspace =
     input.runningLock &&
@@ -111,6 +116,18 @@ export function decideLaunchAction(input: DecideLaunchActionInput): LocalCompani
         toCwd: input.requestedCwd,
         message: formatSwitchMessage(input.runningLock.cwd, input.requestedCwd),
         failureMessage: formatSwitchFailureMessage(input.runningLock.cwd),
+      };
+    }
+
+    if (
+      input.endpoint &&
+      input.endpointIsReachable &&
+      input.companionIsAlive &&
+      (input.endpoint.companionStatus === "stopped" || input.endpoint.companionStatus === "error")
+    ) {
+      return {
+        kind: "restart_unhealthy",
+        message: formatRestartUnhealthyMessage(input.requestedCwd),
       };
     }
 
@@ -411,6 +428,18 @@ async function ensureBridgeReady(
     if (!endpoint) {
       await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
     }
+    return { shouldOpenCompanion: true };
+  }
+
+  if (decision.kind === "restart_unhealthy") {
+    if (!lock || !lockIsAlive) {
+      throw new Error("Cannot restart unhealthy workspace because the active bridge lock is missing.");
+    }
+
+    await stopExistingBridge(lock, options.adapter);
+    log(options.adapter, `Starting replacement bridge in background for ${options.cwd}...`);
+    startBridgeInBackground(options);
+    await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
     return { shouldOpenCompanion: true };
   }
 

--- a/src/companion/local-companion-start.ts
+++ b/src/companion/local-companion-start.ts
@@ -17,6 +17,7 @@ import {
   type BridgeLockPayload,
 } from "../bridge/bridge-state.ts";
 import {
+  clearLocalCompanionOccupancy,
   clearLocalCompanionEndpoint,
   readLocalCompanionEndpoint,
   type LocalCompanionEndpoint,
@@ -30,6 +31,33 @@ type LocalCompanionStartCliOptions = {
   cwd: string;
   profile?: string;
   timeoutMs: number;
+};
+
+type EnsureBridgeReadyResult = {
+  shouldOpenCompanion: boolean;
+};
+
+export type LocalCompanionLaunchDecision =
+  | { kind: "already_active"; message: string }
+  | { kind: "open_companion"; message: string }
+  | {
+      kind: "switch_workspace";
+      fromCwd: string;
+      toCwd: string;
+      message: string;
+      failureMessage: string;
+    }
+  | { kind: "start_bridge"; message: string };
+
+type DecideLaunchActionInput = {
+  requestedAdapter: LocalCompanionLaunchAdapter;
+  requestedCwd: string;
+  runningLock: BridgeLockPayload | null;
+  lockIsAlive: boolean;
+  lockShouldAutoReclaim: boolean;
+  endpoint: LocalCompanionEndpoint | null;
+  endpointIsReachable: boolean;
+  companionIsAlive: boolean;
 };
 
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -47,6 +75,76 @@ export function normalizeComparablePath(cwd: string): string {
 
 export function isSameWorkspaceCwd(left: string, right: string): boolean {
   return normalizeComparablePath(left) === normalizeComparablePath(right);
+}
+
+export function formatAlreadyActiveMessage(cwd: string): string {
+  return `Current workspace is already active: ${cwd}. Visible companion is already running, so nothing else was opened.`;
+}
+
+export function formatSwitchMessage(fromCwd: string, toCwd: string): string {
+  return `Detected active workspace ${fromCwd}. Switching to ${toCwd}...`;
+}
+
+export function formatSwitchFailureMessage(cwd: string): string {
+  return `Failed to stop the previous workspace bridge. Switch canceled; current workspace remains ${cwd}.`;
+}
+
+export function decideLaunchAction(input: DecideLaunchActionInput): LocalCompanionLaunchDecision {
+  const sameWorkspace =
+    input.runningLock &&
+    input.lockIsAlive &&
+    input.runningLock.adapter === input.requestedAdapter &&
+    isSameWorkspaceCwd(input.runningLock.cwd, input.requestedCwd);
+
+  if (input.runningLock && input.lockIsAlive) {
+    if (input.lockShouldAutoReclaim) {
+      return {
+        kind: "start_bridge",
+        message: `Starting replacement bridge in background for ${input.requestedCwd}...`,
+      };
+    }
+
+    if (!sameWorkspace) {
+      return {
+        kind: "switch_workspace",
+        fromCwd: input.runningLock.cwd,
+        toCwd: input.requestedCwd,
+        message: formatSwitchMessage(input.runningLock.cwd, input.requestedCwd),
+        failureMessage: formatSwitchFailureMessage(input.runningLock.cwd),
+      };
+    }
+
+    if (input.endpoint && input.endpointIsReachable && input.companionIsAlive) {
+      return {
+        kind: "already_active",
+        message: formatAlreadyActiveMessage(input.requestedCwd),
+      };
+    }
+
+    return {
+      kind: "open_companion",
+      message: `Found running bridge for ${input.requestedCwd}. Opening companion...`,
+    };
+  }
+
+  if (input.endpoint && input.endpointIsReachable && input.companionIsAlive) {
+    return {
+      kind: "already_active",
+      message: formatAlreadyActiveMessage(input.requestedCwd),
+    };
+  }
+
+  if (input.endpoint && input.endpointIsReachable) {
+    return {
+      kind: "open_companion",
+      message: `Reusing running bridge for ${input.requestedCwd}. Opening companion...`,
+    };
+  }
+
+  return {
+    kind: "start_bridge",
+    message: `Starting bridge in background for ${input.requestedCwd}...`,
+  };
 }
 
 export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
@@ -215,6 +313,19 @@ async function readUsableEndpoint(
   return null;
 }
 
+function isCompanionAlive(endpoint: LocalCompanionEndpoint | null): boolean {
+  if (!endpoint?.companionPid) {
+    return false;
+  }
+
+  if (isPidAlive(endpoint.companionPid)) {
+    return true;
+  }
+
+  clearLocalCompanionOccupancy(endpoint.cwd, endpoint.instanceId);
+  return false;
+}
+
 export function buildBackgroundBridgeArgs(
   entryPath: string,
   options: LocalCompanionStartCliOptions,
@@ -273,39 +384,57 @@ async function waitForEndpoint(
   );
 }
 
-async function ensureBridgeReady(options: LocalCompanionStartCliOptions): Promise<void> {
+async function ensureBridgeReady(
+  options: LocalCompanionStartCliOptions,
+): Promise<EnsureBridgeReadyResult> {
   const lock = readBridgeLockFile();
-  if (lock && isPidAlive(lock.pid)) {
-    if (shouldAutoReclaimBridgeLock(lock)) {
-      await stopExistingBridge(lock, options.adapter);
-      log(options.adapter, `Starting replacement bridge in background for ${options.cwd}...`);
-      startBridgeInBackground(options);
+  const lockIsAlive = Boolean(lock && isPidAlive(lock.pid));
+  const endpoint = await readUsableEndpoint(options.cwd, options.adapter);
+  const decision = decideLaunchAction({
+    requestedAdapter: options.adapter,
+    requestedCwd: options.cwd,
+    runningLock: lock,
+    lockIsAlive,
+    lockShouldAutoReclaim: lockIsAlive && lock ? shouldAutoReclaimBridgeLock(lock) : false,
+    endpoint,
+    endpointIsReachable: Boolean(endpoint),
+    companionIsAlive: isCompanionAlive(endpoint),
+  });
+
+  log(options.adapter, decision.message);
+
+  if (decision.kind === "already_active") {
+    return { shouldOpenCompanion: false };
+  }
+
+  if (decision.kind === "open_companion") {
+    if (!endpoint) {
       await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
-      return;
+    }
+    return { shouldOpenCompanion: true };
+  }
+
+  if (decision.kind === "switch_workspace") {
+    if (!lock || !lockIsAlive) {
+      throw new Error("Cannot switch workspace because the active bridge lock is missing.");
     }
 
-    if (lock.adapter !== options.adapter || !isSameWorkspaceCwd(lock.cwd, options.cwd)) {
+    try {
       await stopExistingBridge(lock, options.adapter);
-      log(options.adapter, `Starting replacement bridge in background for ${options.cwd}...`);
-      startBridgeInBackground(options);
-      await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
-      return;
+    } catch (error) {
+      log(options.adapter, decision.failureMessage);
+      throw error;
     }
 
-    log(options.adapter, `Found running bridge for ${options.cwd}. Waiting for endpoint...`);
+    log(options.adapter, `Starting replacement bridge in background for ${options.cwd}...`);
+    startBridgeInBackground(options);
     await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
-    return;
+    return { shouldOpenCompanion: true };
   }
 
-  const existingEndpoint = await readUsableEndpoint(options.cwd, options.adapter);
-  if (existingEndpoint) {
-    log(options.adapter, `Reusing running bridge for ${options.cwd}.`);
-    return;
-  }
-
-  log(options.adapter, `Starting bridge in background for ${options.cwd}...`);
   startBridgeInBackground(options);
   await waitForEndpoint(options.cwd, options.adapter, options.timeoutMs);
+  return { shouldOpenCompanion: true };
 }
 
 async function runCompanion(options: LocalCompanionStartCliOptions): Promise<number> {
@@ -346,7 +475,10 @@ async function main(): Promise<void> {
     throw new Error(`Missing WeChat credentials. Run "bun run setup" first. (${CREDENTIALS_FILE})`);
   }
 
-  await ensureBridgeReady(options);
+  const ready = await ensureBridgeReady(options);
+  if (!ready.shouldOpenCompanion) {
+    process.exit(0);
+  }
   const exitCode = await runCompanion(options);
   process.exit(exitCode);
 }

--- a/test/bridge/bridge-adapters.core.test.ts
+++ b/test/bridge/bridge-adapters.core.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { shouldStopBridgeAfterCompanionDisconnect } from "../../src/bridge/bridge-adapters.core.ts";
+import {
+  buildCompanionHealthPatch,
+  shouldStopBridgeAfterCompanionDisconnect,
+} from "../../src/bridge/bridge-adapters.core.ts";
 
 describe("local companion proxy lifecycle", () => {
   test("persistent bridges stay alive after companion disconnect", () => {
@@ -13,5 +16,24 @@ describe("local companion proxy lifecycle", () => {
 
   test("undefined lifecycle keeps the historical persistent behavior", () => {
     expect(shouldStopBridgeAfterCompanionDisconnect(undefined)).toBe(false);
+  });
+
+  test("buildCompanionHealthPatch persists stopped worker state for auto-heal decisions", () => {
+    expect(
+      buildCompanionHealthPatch(
+        {
+          kind: "codex",
+          status: "stopped",
+          pid: undefined,
+          cwd: "D:/work/project",
+          command: "codex",
+        },
+        "2026-03-28T00:08:00.000Z",
+      ),
+    ).toEqual({
+      companionStatus: "stopped",
+      companionLastStateAt: "2026-03-28T00:08:00.000Z",
+      companionWorkerPid: undefined,
+    });
   });
 });

--- a/test/companion/local-companion-link.test.ts
+++ b/test/companion/local-companion-link.test.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+const tempDirs: string[] = [];
+
+function makeTempDataDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wechat-link-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function loadLocalCompanionLinkModule(dataDir: string) {
+  const previous = process.env.CLAUDE_WECHAT_CHANNEL_DATA_DIR;
+  process.env.CLAUDE_WECHAT_CHANNEL_DATA_DIR = dataDir;
+
+  try {
+    return await import(`../../src/companion/local-companion-link.ts?test=${Date.now()}-${Math.random()}`);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CLAUDE_WECHAT_CHANNEL_DATA_DIR;
+    } else {
+      process.env.CLAUDE_WECHAT_CHANNEL_DATA_DIR = previous;
+    }
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("local companion endpoint occupancy", () => {
+  test("readLocalCompanionEndpoint preserves companion occupancy metadata", async () => {
+    const dataDir = makeTempDataDir();
+    const cwd = "D:/work/project-a";
+    const link = await loadLocalCompanionLinkModule(dataDir);
+
+    link.writeLocalCompanionEndpoint({
+      instanceId: "bridge-1",
+      kind: "codex",
+      port: 8123,
+      token: "token-1",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:00:00.000Z",
+      companionPid: 456,
+      companionConnectedAt: "2026-03-28T00:01:00.000Z",
+    });
+
+    expect(link.readLocalCompanionEndpoint(cwd)).toEqual({
+      instanceId: "bridge-1",
+      kind: "codex",
+      port: 8123,
+      token: "token-1",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:00:00.000Z",
+      companionPid: 456,
+      companionConnectedAt: "2026-03-28T00:01:00.000Z",
+      profile: undefined,
+      sharedSessionId: undefined,
+      sharedThreadId: undefined,
+      resumeConversationId: undefined,
+      transcriptPath: undefined,
+    });
+  });
+
+  test("clearLocalCompanionOccupancy removes only companion metadata", async () => {
+    const dataDir = makeTempDataDir();
+    const cwd = "D:/work/project-b";
+    const link = await loadLocalCompanionLinkModule(dataDir);
+
+    link.writeLocalCompanionEndpoint({
+      instanceId: "bridge-2",
+      kind: "codex",
+      port: 9001,
+      token: "token-2",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:02:00.000Z",
+      companionPid: 789,
+      companionConnectedAt: "2026-03-28T00:03:00.000Z",
+    });
+
+    link.clearLocalCompanionOccupancy(cwd);
+
+    expect(link.readLocalCompanionEndpoint(cwd)).toEqual({
+      instanceId: "bridge-2",
+      kind: "codex",
+      port: 9001,
+      token: "token-2",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:02:00.000Z",
+      companionPid: undefined,
+      companionConnectedAt: undefined,
+      profile: undefined,
+      sharedSessionId: undefined,
+      sharedThreadId: undefined,
+      resumeConversationId: undefined,
+      transcriptPath: undefined,
+    });
+  });
+
+  test("updateLocalCompanionOccupancy stores companion metadata without touching endpoint identity", async () => {
+    const dataDir = makeTempDataDir();
+    const cwd = "D:/work/project-c";
+    const link = await loadLocalCompanionLinkModule(dataDir);
+
+    link.writeLocalCompanionEndpoint({
+      instanceId: "bridge-3",
+      kind: "codex",
+      port: 9010,
+      token: "token-3",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:04:00.000Z",
+    });
+
+    link.updateLocalCompanionOccupancy(cwd, {
+      companionPid: 1001,
+      companionConnectedAt: "2026-03-28T00:05:00.000Z",
+    });
+
+    expect(link.readLocalCompanionEndpoint(cwd)).toEqual({
+      instanceId: "bridge-3",
+      kind: "codex",
+      port: 9010,
+      token: "token-3",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:04:00.000Z",
+      companionPid: 1001,
+      companionConnectedAt: "2026-03-28T00:05:00.000Z",
+      profile: undefined,
+      sharedSessionId: undefined,
+      sharedThreadId: undefined,
+      resumeConversationId: undefined,
+      transcriptPath: undefined,
+    });
+  });
+});

--- a/test/companion/local-companion-link.test.ts
+++ b/test/companion/local-companion-link.test.ts
@@ -146,4 +146,46 @@ describe("local companion endpoint occupancy", () => {
       transcriptPath: undefined,
     });
   });
+
+  test("updateLocalCompanionHealth stores the latest companion health status", async () => {
+    const dataDir = makeTempDataDir();
+    const cwd = "D:/work/project-d";
+    const link = await loadLocalCompanionLinkModule(dataDir);
+
+    link.writeLocalCompanionEndpoint({
+      instanceId: "bridge-4",
+      kind: "codex",
+      port: 9011,
+      token: "token-4",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:06:00.000Z",
+    });
+
+    link.updateLocalCompanionHealth(cwd, {
+      companionStatus: "stopped",
+      companionLastStateAt: "2026-03-28T00:07:00.000Z",
+      companionWorkerPid: 4321,
+    });
+
+    expect(link.readLocalCompanionEndpoint(cwd)).toEqual({
+      instanceId: "bridge-4",
+      kind: "codex",
+      port: 9011,
+      token: "token-4",
+      cwd,
+      command: "codex",
+      startedAt: "2026-03-28T00:06:00.000Z",
+      companionStatus: "stopped",
+      companionLastStateAt: "2026-03-28T00:07:00.000Z",
+      companionWorkerPid: 4321,
+      companionPid: undefined,
+      companionConnectedAt: undefined,
+      profile: undefined,
+      sharedSessionId: undefined,
+      sharedThreadId: undefined,
+      resumeConversationId: undefined,
+      transcriptPath: undefined,
+    });
+  });
 });

--- a/test/companion/local-companion-start.test.ts
+++ b/test/companion/local-companion-start.test.ts
@@ -192,4 +192,43 @@ describe("local-companion-start helpers", () => {
       failureMessage: formatSwitchFailureMessage("D:/work/project-a"),
     });
   });
+
+  test("same workspace with a stopped companion requests auto-heal restart", () => {
+    const decision = decideLaunchAction({
+      requestedAdapter: "codex",
+      requestedCwd: "D:/work/project",
+      runningLock: {
+        pid: 123,
+        parentPid: 321,
+        instanceId: "bridge-1",
+        adapter: "codex",
+        command: "codex",
+        cwd: "D:/work/project",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        lifecycle: "companion_bound",
+      },
+      lockIsAlive: true,
+      lockShouldAutoReclaim: false,
+      endpoint: {
+        instanceId: "bridge-1",
+        kind: "codex",
+        port: 8123,
+        token: "token",
+        cwd: "D:/work/project",
+        command: "codex",
+        startedAt: "2026-03-28T00:01:00.000Z",
+        companionPid: 456,
+        companionConnectedAt: "2026-03-28T00:02:00.000Z",
+        companionStatus: "stopped",
+        companionLastStateAt: "2026-03-28T00:03:00.000Z",
+      },
+      endpointIsReachable: true,
+      companionIsAlive: true,
+    });
+
+    expect(decision).toEqual({
+      kind: "restart_unhealthy",
+      message: "Detected unhealthy companion state for D:/work/project. Restarting bridge...",
+    });
+  });
 });

--- a/test/companion/local-companion-start.test.ts
+++ b/test/companion/local-companion-start.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 
 import {
   buildBackgroundBridgeArgs,
+  decideLaunchAction,
+  formatAlreadyActiveMessage,
+  formatSwitchFailureMessage,
+  formatSwitchMessage,
   isSameWorkspaceCwd,
   normalizeComparablePath,
   parseCliArgs,
@@ -85,5 +89,107 @@ describe("local-companion-start helpers", () => {
 
   test("isSameWorkspaceCwd matches equivalent directory paths", () => {
     expect(isSameWorkspaceCwd(".", process.cwd())).toBe(true);
+  });
+
+  test("same workspace with live companion is already active", () => {
+    const decision = decideLaunchAction({
+      requestedAdapter: "codex",
+      requestedCwd: "D:/work/project",
+      runningLock: {
+        pid: 123,
+        parentPid: 321,
+        instanceId: "bridge-1",
+        adapter: "codex",
+        command: "codex",
+        cwd: "D:/work/project",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        lifecycle: "companion_bound",
+      },
+      lockIsAlive: true,
+      lockShouldAutoReclaim: false,
+      endpoint: {
+        instanceId: "bridge-1",
+        kind: "codex",
+        port: 8123,
+        token: "token",
+        cwd: "D:/work/project",
+        command: "codex",
+        startedAt: "2026-03-28T00:01:00.000Z",
+        companionPid: 456,
+        companionConnectedAt: "2026-03-28T00:02:00.000Z",
+      },
+      endpointIsReachable: true,
+      companionIsAlive: true,
+    });
+
+    expect(decision).toEqual({
+      kind: "already_active",
+      message: formatAlreadyActiveMessage("D:/work/project"),
+    });
+  });
+
+  test("same workspace reopens companion when bridge is alive but companion is gone", () => {
+    const decision = decideLaunchAction({
+      requestedAdapter: "codex",
+      requestedCwd: "D:/work/project",
+      runningLock: {
+        pid: 123,
+        parentPid: 321,
+        instanceId: "bridge-1",
+        adapter: "codex",
+        command: "codex",
+        cwd: "D:/work/project",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        lifecycle: "companion_bound",
+      },
+      lockIsAlive: true,
+      lockShouldAutoReclaim: false,
+      endpoint: {
+        instanceId: "bridge-1",
+        kind: "codex",
+        port: 8123,
+        token: "token",
+        cwd: "D:/work/project",
+        command: "codex",
+        startedAt: "2026-03-28T00:01:00.000Z",
+      },
+      endpointIsReachable: true,
+      companionIsAlive: false,
+    });
+
+    expect(decision).toEqual({
+      kind: "open_companion",
+      message: "Found running bridge for D:/work/project. Opening companion...",
+    });
+  });
+
+  test("different workspace requests an explicit switch", () => {
+    const decision = decideLaunchAction({
+      requestedAdapter: "codex",
+      requestedCwd: "D:/work/project-b",
+      runningLock: {
+        pid: 123,
+        parentPid: 321,
+        instanceId: "bridge-1",
+        adapter: "codex",
+        command: "codex",
+        cwd: "D:/work/project-a",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        lifecycle: "companion_bound",
+      },
+      lockIsAlive: true,
+      lockShouldAutoReclaim: false,
+      endpoint: null,
+      endpointIsReachable: false,
+      companionIsAlive: false,
+    });
+
+    expect(decision).toEqual({
+      kind: "switch_workspace",
+      fromCwd: "D:/work/project-a",
+      toCwd: "D:/work/project-b",
+      message: formatSwitchMessage("D:/work/project-a", "D:/work/project-b"),
+      failureMessage: formatSwitchFailureMessage("D:/work/project-a"),
+    });
   });
 });


### PR DESCRIPTION
## Summary
- persist companion health metadata in the local endpoint
- auto-restart the current workspace bridge when the companion stays connected but reports a stopped/error worker
- document and test the new auto-heal behavior

## Test Plan
- bun test test
