### PR TITLE
fix: preserve proxy env vars for Windows bridge launches

### DIFF
--- a/src/bridge/bridge-adapters.shared.ts
+++ b/src/bridge/bridge-adapters.shared.ts
@@ -877,6 +877,14 @@ export function buildCliEnvironment(
       "ProgramFiles(x86)",
       "CommonProgramFiles",
       "CommonProgramFiles(x86)",
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "ALL_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "all_proxy",
+      "NO_PROXY",
+      "no_proxy",
     ] as const;
 
     for (const key of keys) {


### PR DESCRIPTION
## Summary
- preserve proxy-related environment variables when building the Windows CLI env for Codex/Claude/OpenCode bridge launches
- keep loopback NO_PROXY handling intact so local bridge connections still bypass the proxy

## 中文说明
这个 PR 只改了一处 Windows 环境变量白名单，目的是让 bridge 拉起的 `codex` / `claude` / `opencode` 子进程能够继承父 shell 里已经设置好的代理。

改动范围很小：
- 仅在 `src/bridge/bridge-adapters.shared.ts` 的 Windows `buildCliEnvironment()` 白名单里新增 8 个代理相关变量
- 不修改启动参数、不改 spawn 逻辑、不改非 Windows 分支

为什么要改：
- 当前 `wechat-codex-start` / `wechat-bridge-codex` 会继承父 shell 环境，但在 Windows 下真正启动 `codex` 子进程时，会重建一份精简 env
- 旧逻辑里没有把 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` 及对应大小写变体透传进去
- 结果是 bridge 本身可以联网，但被 bridge 拉起的 `codex` 进程不一定会走代理

这次新增的变量：
- `HTTP_PROXY`
- `HTTPS_PROXY`
- `ALL_PROXY`
- `http_proxy`
- `https_proxy`
- `all_proxy`
- `NO_PROXY`
- `no_proxy`

风险评估：
- 低风险
- 只是把父进程里已存在的代理变量继续传递给子进程
- 原有的 loopback `NO_PROXY` 合并逻辑保持不变，本地 websocket / localhost 连接仍然会绕过代理

## Validation
- verified `buildCliEnvironment("codex")` retains `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, and `no_proxy` when set in the parent shell
