### PR TITLE
fix: isolate codex fallback sessions from desktop traffic

### DIFF
--- a/src/bridge/bridge-adapters.shared.ts
+++ b/src/bridge/bridge-adapters.shared.ts
@@ -1182,6 +1182,20 @@ export function getCodexSessionSource(meta: CodexSessionMeta | null | undefined)
   return null;
 }
 
+export function isTrustedCodexFallbackSession(meta: CodexSessionMeta | null | undefined): boolean {
+  const sessionSource = getCodexSessionSource(meta);
+  if (!sessionSource) {
+    return false;
+  }
+
+  if (sessionSource === "cli") {
+    return true;
+  }
+
+  const originator = normalizeOutput(meta?.originator ?? "").trim().toLowerCase();
+  return sessionSource === "vscode" && originator === "wechat-bridge";
+}
+
 export function parseCodexSessionUserMessage(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) {
@@ -1401,6 +1415,10 @@ export function findRecentCodexSessionFileForCwd(
   for (const filePath of listCodexSessionFilesRecursively(sessionsRoot)) {
     const meta = readCodexSessionMeta(filePath);
     if (!meta?.id || !meta.cwd || normalizeComparablePath(meta.cwd) !== currentCwd) {
+      continue;
+    }
+
+    if (!isTrustedCodexFallbackSession(meta)) {
       continue;
     }
 

--- a/test/bridge/bridge-adapters.test.ts
+++ b/test/bridge/bridge-adapters.test.ts
@@ -1857,6 +1857,101 @@ describe("findRecentCodexSessionFileForCwd", () => {
     expect(recent?.threadId).toBe("thread_historical_123");
     expect(recent?.filePath).toBe(sessionFilePath);
   });
+
+  test("only accepts trusted CLI or wechat-bridge vscode sessions for recent fallback", () => {
+    const homeDirectory = makeTempDirectory();
+    process.env.HOME = homeDirectory;
+    process.env.USERPROFILE = homeDirectory;
+
+    const cwd = "C:\\repo";
+    const desktopSessionPath = path.join(
+      homeDirectory,
+      ".codex",
+      "sessions",
+      "2026",
+      "03",
+      "23",
+      "desktop-thread.jsonl",
+    );
+    const bridgeSessionPath = path.join(
+      homeDirectory,
+      ".codex",
+      "sessions",
+      "2026",
+      "03",
+      "23",
+      "bridge-thread.jsonl",
+    );
+    const foreignVscodeSessionPath = path.join(
+      homeDirectory,
+      ".codex",
+      "sessions",
+      "2026",
+      "03",
+      "23",
+      "foreign-vscode-thread.jsonl",
+    );
+
+    writeTextFile(
+      desktopSessionPath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "thread_desktop",
+            cwd,
+            source: "vscode",
+            originator: "Codex Desktop",
+            timestamp: "2026-03-23T12:00:00.000Z",
+          },
+        }),
+      ].join("\n"),
+    );
+    const desktopMtime = new Date("2026-03-23T12:00:08.000Z");
+    fs.utimesSync(desktopSessionPath, desktopMtime, desktopMtime);
+
+    writeTextFile(
+      foreignVscodeSessionPath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "thread_foreign_vscode",
+            cwd,
+            source: "vscode",
+            originator: "Some Other Integration",
+            timestamp: "2026-03-23T12:00:00.500Z",
+          },
+        }),
+      ].join("\n"),
+    );
+    const foreignMtime = new Date("2026-03-23T12:00:09.000Z");
+    fs.utimesSync(foreignVscodeSessionPath, foreignMtime, foreignMtime);
+
+    writeTextFile(
+      bridgeSessionPath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "thread_bridge",
+            cwd,
+            source: "vscode",
+            originator: "wechat-bridge",
+            timestamp: "2026-03-23T12:00:01.000Z",
+          },
+        }),
+      ].join("\n"),
+    );
+    const bridgeMtime = new Date("2026-03-23T12:00:05.000Z");
+    fs.utimesSync(bridgeSessionPath, bridgeMtime, bridgeMtime);
+
+    const recent = findRecentCodexSessionFileForCwd(cwd, Date.parse("2026-03-23T12:00:00.000Z"));
+
+    expect(recent).not.toBeNull();
+    expect(recent?.threadId).toBe("thread_bridge");
+    expect(recent?.filePath).toBe(bridgeSessionPath);
+  });
 });
 
 describe("extractCodexFinalTextFromItem", () => {


### PR DESCRIPTION
## Summary
This PR tightens Codex session fallback isolation so the WeChat bridge only considers trusted fallback sessions created by the bridge/CLI itself.

## Problem
On machines where Codex Desktop had already been installed and used in the same workspace, the bridge could incorrectly follow Desktop-owned session files under `~/.codex/sessions`.

That produced a few bad behaviors:
- WeChat inbound messages were forwarded into a stale or unrelated thread and failed with `thread not found`.
- WeChat was flooded with `Codex thread switched ...` notices.
- Codex Desktop conversations from the same workspace could leak into the WeChat bridge flow.

## How To Reproduce
1. Install and use Codex Desktop in a workspace such as `C:\Users\admin\codex\mwi`.
2. Let Codex Desktop create/update session files under `~/.codex/sessions` for that same `cwd`.
3. Start `wechat-codex-start` in the same workspace.
4. Send a message from WeChat.
5. Observe that the bridge may fall back to an unrelated Desktop thread, emit repeated thread-switch logs, and fail inbound delivery with `thread not found`.

## Root Cause
`findRecentCodexSessionFileForCwd(...)` scanned recent session files by `cwd` and recency, but it did not sufficiently isolate the fallback candidate source.

Because Codex Desktop and the bridge can both write session files for the same workspace, a newer Desktop-owned `vscode` session could win the fallback selection and overwrite the bridge's shared thread id.

## Solution
This PR introduces a stricter trust rule for Codex fallback sessions:
- allow `source = cli`
- allow `source = vscode` only when `originator = wechat-bridge`
- reject other `vscode` sessions, including `Codex Desktop`

This keeps the existing fallback mechanism for bridge/CLI recovery, while preventing unrelated Desktop traffic from being treated as the active bridge thread.

## Validation
- Added a regression test that mixes three session types for the same workspace:
  - Codex Desktop `vscode`
  - foreign `vscode`
  - trusted `wechat-bridge` `vscode`
- Verified that the fallback now selects only the trusted bridge session.
- Ran `bun test test`

## Risks / Remaining Limitations
- This still relies on session metadata conventions. If upstream Codex changes the `source` / `originator` shape again, the trust filter may need to be updated.
- This PR intentionally keeps the fallback behavior instead of removing it entirely, so recovery still depends on trusted session files existing when explicit follow signals are missing.
- Existing local dirty worktrees or unrelated bridge patches are not part of this PR.
