### PR TITLE
fix(opencode): filter reasoning parts and improve reply sanitization

### DIFF
--- a/src/bridge/bridge-adapters.opencode.ts
+++ b/src/bridge/bridge-adapters.opencode.ts
@@ -226,6 +226,7 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
   private readonly observedUserTextByPartId = new Map<string, string>();
   private readonly observedUserMessagePartIds = new Map<string, Set<string>>();
   private readonly pendingWechatPromptMirrorSuppressions: PendingWechatPromptMirrorSuppression[] = [];
+  private readonly reasoningPartIds = new Set<string>();
   private readonly recentSdkEventObservations = new Map<
     string,
     { streamName: SdkEventStreamName; observedAtMs: number }
@@ -1010,7 +1011,8 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
       void this.outputBatcher.flushNow()
         .catch(() => undefined)
         .then(() => {
-          const summary = this.outputBatcher.getRecentSummary(500);
+          // WeChat single message limit is ~2048 chars, request up to 2000
+          const summary = this.outputBatcher.getRecentSummary(2000);
           this.setStatus("idle");
           if (summary && summary !== "(no output)") {
             this.emit({
@@ -1222,6 +1224,13 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
     }
 
     const part = isRecord(properties.part) ? properties.part : undefined;
+
+    // Track reasoning parts to filter them out later
+    if (part && part.type === "reasoning" && part.id) {
+      this.reasoningPartIds.add(part.id);
+      return;
+    }
+
     if (this.isVisibleTextPart(part)) {
       this.trackObservedOpenCodeMessagePart({
         messageId: part.messageID,
@@ -1249,6 +1258,11 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
 
     const partId = this.extractPartId(properties, part);
     if (!partId) {
+      return;
+    }
+
+    // Skip reasoning parts
+    if (this.reasoningPartIds.has(partId)) {
       return;
     }
 
@@ -1320,6 +1334,11 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
     }
 
     if (!delta || !partId || !this.syncTrackedSessionFromEvent(sessionId)) {
+      return;
+    }
+
+    // Skip reasoning part deltas
+    if (this.reasoningPartIds.has(partId)) {
       return;
     }
 

--- a/src/bridge/bridge-utils.ts
+++ b/src/bridge/bridge-utils.ts
@@ -722,12 +722,15 @@ export function summarizeOutput(text: string, maxLength = 280): string {
     return "(no output)";
   }
 
-  const summary = normalized.slice(-6).join("\n");
-  if (summary.length <= maxLength) {
-    return summary;
+  let result = "";
+  for (const line of normalized) {
+    const next = result ? `${result}\n${line}` : line;
+    if (next.length > maxLength) {
+      break;
+    }
+    result = next;
   }
-
-  return summary.slice(summary.length - maxLength);
+  return result || "(output truncated)";
 }
 
 export function formatStatusReport(
@@ -893,9 +896,9 @@ export function formatMirroredUserInputMessage(
       : adapter === "claude"
         ? "Local Claude input"
         : adapter === "opencode"
-          ? "Local OpenCode input"
+          ? "Ask"
           : "Local input";
-  return `${label}:\n${truncatePreview(text, 500)}`;
+  return `${label}: ${truncatePreview(text, 500)}`;
 }
 
 export function formatFinalReplyMessage(
@@ -920,20 +923,20 @@ const OPENCODE_TRANSIENT_NOTICE_RES = [
 ];
 const OPENCODE_REASONING_LINE_RES = [
   /\bCLAUDE\.md\b/i,
-  /\bNo tool needed\.?$/i,
-  /\bThe user said\b/i,
-  /\bI need to (?:respond|reply|answer|tell the user)\b/i,
-  /\bWe need to (?:respond|reply|answer)\b/i,
-  /\bI should\b/i,
-  /\bI'll provide\b/i,
-  /^Let me (?:directly )?(?:answer|respond)\b/i,
-  /根据系统提示/i,
-  /系统提示中说/i,
-  /我需要(?:告诉用户|回答|回复)/,
-  /我们需要(?:回答|回复)/,
-  /^让我直接(?:回答|回复)/,
-  /^我要直接(?:回答|回复)/,
-  /^用户(?:说|问)了/,
+  // /\bNo tool needed\.?$/i,
+  // /\bThe user said\b/i,
+  // /\bI need to (?:respond|reply|answer|tell the user)\b/i,
+  // /\bWe need to (?:respond|reply|answer)\b/i,
+  // /\bI should\b/i,
+  // /\bI'll provide\b/i,
+  // /^Let me (?:directly )?(?:answer|respond)\b/i,
+  // /根据系统提示/i,
+  // /系统提示中说/i,
+  // /我需要(?:告诉用户|回答|回复)/,
+  // /我们需要(?:回答|回复)/,
+  // /^让我直接(?:回答|回复)/,
+  // /^我要直接(?:回答|回复)/,
+  // /^用户(?:说|问)了/,
 ];
 
 export function sanitizeWechatFinalReplyText(
@@ -945,12 +948,18 @@ export function sanitizeWechatFinalReplyText(
     return normalized;
   }
 
+  const lines = normalized.split("\n");
+  // Remove first line (user question echo)
+  if (lines.length > 1) {
+    lines.shift();
+  }
+
   const keptLines: string[] = [];
   let dropNextContextLine = false;
   let sawDroppedMeta = false;
   let tailStartIndex = 0;
 
-  for (const rawLine of normalized.split("\n")) {
+  for (const rawLine of lines) {
     const line = rawLine.trim();
     if (!line) {
       keptLines.push("");


### PR DESCRIPTION
- Track reasoning part IDs and skip them in message output
- Increase summary length from 500 to 2000 chars
- Remove first line (user question echo) from sanitized reply
- Simplify summarizeOutput truncation logic
- Update opencode local input label to "Ask"
- Comment out overly aggressive reasoning line patterns