### PR TITLE
feat(claude): forward real-time thinking content to WeChat

### DIFF
--- a/src/bridge/bridge-adapters.claude.ts
+++ b/src/bridge/bridge-adapters.claude.ts
@@ -30,6 +30,7 @@ import type {
 } from "./bridge-types.ts";
 import {
   detectCliApproval,
+  isThinkingForwardEnabled,
   normalizeOutput,
   nowIso,
   truncatePreview,
@@ -1203,6 +1204,9 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
   private startTranscriptThinkingWatch(): void {
     this.stopTranscriptThinkingWatch();
     if (!this.transcriptPath) {
+      return;
+    }
+    if (!isThinkingForwardEnabled()) {
       return;
     }
 

--- a/src/bridge/bridge-adapters.claude.ts
+++ b/src/bridge/bridge-adapters.claude.ts
@@ -250,6 +250,7 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
     this.pendingCliApprovalHints = null;
     this.clearWechatWorkingNotice(true);
     this.setStatus("busy");
+    this.startTranscriptThinkingWatch();
     this.writeToPty(this.buildRemoteInputPayload(text));
     await delay(CLAUDE_REMOTE_ENTER_DELAY_MS);
     this.writeToPty("\r");
@@ -1013,6 +1014,7 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
     this.pendingCliApprovalHints = null;
     this.clearWechatWorkingNotice(true);
     this.setStatus("busy");
+    this.startTranscriptThinkingWatch();
     this.emit({
       type: "mirrored_user_input",
       text: prompt,

--- a/src/bridge/bridge-adapters.claude.ts
+++ b/src/bridge/bridge-adapters.claude.ts
@@ -159,6 +159,9 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
   private lastCompactCompletionAtMs = 0;
   private startupOutputBuffer = "";
   private hasAutoConfirmedWorkspaceTrustPrompt = false;
+  private transcriptPollTimer: ReturnType<typeof setInterval> | null = null;
+  private transcriptTailOffset = 0;
+  private polledTranscriptSessionId: string | null = null;
 
   constructor(options: AdapterOptions) {
     super(options);
@@ -366,6 +369,7 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
     this.clearWechatWorkingNotice(true);
     this.pendingCliApprovalHints = null;
     this.flushPendingClaudeHookApprovals();
+    this.stopTranscriptThinkingWatch();
     await super.dispose();
     await this.stopHookServer();
   }
@@ -963,6 +967,7 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
     this.state.resumeConversationId = nextResumeConversationId ?? undefined;
     this.transcriptPath = nextTranscriptPath;
     this.state.transcriptPath = nextTranscriptPath ?? undefined;
+    this.startTranscriptThinkingWatch();
 
     if (previousRuntimeSessionId === payload.session_id) {
       return;
@@ -1180,6 +1185,7 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
       summary: this.currentPreview,
       timestamp: nowIso(),
     });
+    this.stopTranscriptThinkingWatch();
     this.currentPreview = "(idle)";
   }
 
@@ -1188,7 +1194,99 @@ export class ClaudeCompanionAdapter extends AbstractPtyAdapter {
     error_details?: string;
     last_assistant_message?: string;
   }): void {
+    this.stopTranscriptThinkingWatch();
     this.failClaudeTurn(buildClaudeFailureMessage(payload));
+  }
+
+  private startTranscriptThinkingWatch(): void {
+    this.stopTranscriptThinkingWatch();
+    if (!this.transcriptPath) {
+      return;
+    }
+
+    this.transcriptTailOffset = 0;
+    try {
+      const stat = fs.statSync(this.transcriptPath);
+      this.transcriptTailOffset = stat.size;
+    } catch {
+      return;
+    }
+
+    const watchPath = this.transcriptPath;
+    const sessionId = this.runtimeSessionId;
+    this.polledTranscriptSessionId = sessionId;
+
+    this.transcriptPollTimer = setInterval(() => {
+      if (this.shuttingDown) {
+        this.stopTranscriptThinkingWatch();
+        return;
+      }
+      if (this.polledTranscriptSessionId !== this.runtimeSessionId) {
+        this.stopTranscriptThinkingWatch();
+        return;
+      }
+
+      try {
+        const stat = fs.statSync(watchPath);
+        if (stat.size <= this.transcriptTailOffset) {
+          return;
+        }
+
+        const fd = fs.openSync(watchPath, "r");
+        const buf = Buffer.alloc(stat.size - this.transcriptTailOffset);
+        fs.readSync(fd, buf, 0, buf.length, this.transcriptTailOffset);
+        fs.closeSync(fd);
+        this.transcriptTailOffset = stat.size;
+
+        const newText = buf.toString("utf8");
+        const lines = newText.split(/\r?\n/).filter(Boolean);
+        for (const line of lines) {
+          let parsed: any;
+          try {
+            parsed = JSON.parse(line);
+          } catch {
+            continue;
+          }
+
+          if (
+            !parsed ||
+            parsed.type !== "assistant" ||
+            !Array.isArray(parsed.message?.content)
+          ) {
+            continue;
+          }
+
+          for (const block of parsed.message.content) {
+            if (
+              block.type === "thinking" &&
+              typeof block.thinking === "string" &&
+              block.thinking.trim()
+            ) {
+              const thinking = normalizeOutput(block.thinking).trim();
+              if (thinking) {
+                this.emit({
+                  type: "thinking",
+                  text: thinking,
+                  timestamp: nowIso(),
+                });
+              }
+            }
+          }
+        }
+      } catch {
+        // File may be temporarily locked or deleted; silently retry next poll.
+      }
+    }, 800);
+    this.transcriptPollTimer.unref?.();
+  }
+
+  private stopTranscriptThinkingWatch(): void {
+    if (this.transcriptPollTimer) {
+      clearInterval(this.transcriptPollTimer);
+      this.transcriptPollTimer = null;
+    }
+    this.transcriptTailOffset = 0;
+    this.polledTranscriptSessionId = null;
   }
 
   private respondToClaudeHook(

--- a/src/bridge/bridge-types.ts
+++ b/src/bridge/bridge-types.ts
@@ -151,6 +151,11 @@ export type BridgeEvent =
       timestamp: string;
     }
   | {
+      type: "thinking";
+      text: string;
+      timestamp: string;
+    }
+  | {
       type: "approval_required";
       request: ApprovalRequest | PendingApproval;
       timestamp: string;

--- a/src/bridge/bridge-utils.ts
+++ b/src/bridge/bridge-utils.ts
@@ -208,6 +208,17 @@ export function truncatePreview(text: string, maxLength = 140): string {
   return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
+export function formatThinkingForWechat(text: string, maxLength = 500): string {
+  const normalized = normalizeOutput(text).trim();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
 export function buildOneTimeCode(length = 6): string {
   const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
   let code = "";

--- a/src/bridge/bridge-utils.ts
+++ b/src/bridge/bridge-utils.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -206,6 +207,23 @@ export function truncatePreview(text: string, maxLength = 140): string {
     return normalized;
   }
   return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+export function isThinkingForwardEnabled(): boolean {
+  if (process.env.CLI_BRIDGE_THINKING_FORWARD === "1") {
+    return true;
+  }
+  try {
+    const accountPath = process.env.CLI_BRIDGE_DATA_DIR
+      ? path.join(process.env.CLI_BRIDGE_DATA_DIR, "account.json")
+      : path.join(os.homedir(), ".cli-bridge", "account.json");
+    if (!fs.existsSync(accountPath)) return false;
+    const raw = fs.readFileSync(accountPath, "utf8");
+    const data = JSON.parse(raw) as { enableThinkingForward?: boolean };
+    return data.enableThinkingForward === true;
+  } catch {
+    return false;
+  }
 }
 
 export function formatThinkingForWechat(text: string, maxLength = 500): string {

--- a/src/bridge/wechat-bridge.ts
+++ b/src/bridge/wechat-bridge.ts
@@ -36,6 +36,7 @@ import {
   formatSessionSwitchMessage,
   formatStatusReport,
   formatTaskFailedMessage,
+  formatThinkingForWechat,
   formatUserInputRequestMessage,
   MESSAGE_START_GRACE_MS,
   nowIso,
@@ -1159,7 +1160,7 @@ function wireAdapterEvents(params: {
       case "thinking":
         updateLastOutputAt();
         if (event.text) {
-          const thinkingPreview = truncatePreview(event.text, 300);
+          const thinkingPreview = formatThinkingForWechat(event.text, 500);
           if (thinkingPreview) {
             stateStore.appendLog(`thinking: ${thinkingPreview}`);
             trackWechatForwardTask((async () => {

--- a/src/bridge/wechat-bridge.ts
+++ b/src/bridge/wechat-bridge.ts
@@ -1156,6 +1156,18 @@ function wireAdapterEvents(params: {
           }));
         }
         break;
+      case "thinking":
+        updateLastOutputAt();
+        if (event.text) {
+          const thinkingPreview = truncatePreview(event.text, 300);
+          if (thinkingPreview) {
+            stateStore.appendLog(`thinking: ${thinkingPreview}`);
+            trackWechatForwardTask((async () => {
+              await queueWechatMessage(authorizedUserId, `思考: ${thinkingPreview}`, "thinking");
+            })());
+          }
+        }
+        break;
       case "approval_required":
         trackWechatForwardTask(outputBatcher.flushNow().then(async () => {
           const pending = toPendingApproval(event.request);

--- a/src/wechat/wechat-transport.ts
+++ b/src/wechat/wechat-transport.ts
@@ -48,6 +48,7 @@ export type AccountData = {
   accountId: string;
   userId?: string;
   savedAt: string;
+  enableThinkingForward?: boolean;
 };
 
 type ContextTokenState = Record<string, string>;


### PR DESCRIPTION
Poll the JSONL transcript file (provided by SessionStart hook) every 800ms and emit `thinking` events when new assistant blocks with type "thinking" are detected. The bridge formats them with a prefix and sends them to WeChat via the existing message queue.

- Add transcriptTailOffset / transcriptPollTimer / polledSessionId to ClaudeCompanionAdapter
- startTranscriptThinkingWatch fires after SessionStart hook
- stopTranscriptThinkingWatch runs on Stop, StopFailure, and dispose
- Bridge wireAdapterEvents now handles the "thinking" event type
- BridgeEvent union type gains a "thinking" variant