### PR TITLE
fix(install): restore exec bit on node-pty spawn-helper (fixes Claude --print error on macOS)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,6 +132,26 @@ wechat-daemon --doctor
 
 如果输出 `node-pty: ✓ loaded`，重启 bridge 即可使用完整 PTY 模式。
 
+### spawn-helper 缺少执行权限（macOS / Linux）
+
+即使 `node-pty` 能正常加载（`--doctor` 显示 `node-pty: ✓ loaded`），PTY 仍可能起不来。典型症状是 Claude 适配器报：
+
+```text
+Error: Input must be provided either through stdin or as a prompt argument when using --print
+```
+
+或 bridge 日志中出现 `posix_spawnp failed`。原因是 node-pty 发布包里的 `spawn-helper` 预编译二进制权限为 `0644`（缺少执行位），`posix_spawnp` 无法 exec，导致 PTY 启动失败并回退到非 PTY 模式，而 Claude 适配器在该模式下会进入 `--print` 非交互模式并报错。
+
+本项目的 `postinstall` 脚本会在安装后自动为 `spawn-helper` 补上执行位。如果仍遇到该问题（例如使用了 `--ignore-scripts` 安装），可手动修复：
+
+```bash
+PKG="$(npm root -g)/cli-wechat-bridge/node_modules/node-pty"
+chmod +x "$PKG/prebuilds/darwin-arm64/spawn-helper" \
+         "$PKG/prebuilds/darwin-x64/spawn-helper" 2>/dev/null
+```
+
+修复后重启 bridge 即可恢复完整 PTY 模式。
+
 ## 微信上提示没有 context token
 
 通常表示当前联系人还没有建立可用的 iLink 上下文。启动 bridge 后，先由 owner 账号向 Bot 发送一条普通微信消息，一般即可建立上下文。

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "wechat-check-update": "bin/wechat-check-update.mjs"
   },
   "scripts": {
+    "postinstall": "node scripts/ensure-node-pty-permissions.mjs",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "prepack": "npm run build",

--- a/scripts/ensure-node-pty-permissions.mjs
+++ b/scripts/ensure-node-pty-permissions.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+// Ensure the bundled node-pty `spawn-helper` is executable.
+//
+// node-pty ships its prebuilt `spawn-helper` binaries with mode 0644 (no exec
+// bit) in the published tarball. On macOS/Linux that makes `posix_spawnp`
+// fail when node-pty tries to fork a PTY, so the bridge silently drops to the
+// non-PTY fallback. The Claude adapter relies on PTY interactive mode, so the
+// fallback surfaces to users as:
+//
+//   Error: Input must be provided ... when using --print
+//
+// Restoring the exec bit after install fixes PTY spawning. This runs on
+// postinstall and is idempotent; it never fails the install.
+
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+if (process.platform === "win32") {
+  process.exit(0);
+}
+
+const require = createRequire(import.meta.url);
+
+let nodePtyDir;
+try {
+  nodePtyDir = path.dirname(require.resolve("node-pty/package.json"));
+} catch {
+  // node-pty is optional in unsupported environments; nothing to fix.
+  process.exit(0);
+}
+
+const candidates = [
+  "prebuilds/darwin-arm64/spawn-helper",
+  "prebuilds/darwin-x64/spawn-helper",
+  "prebuilds/linux-x64/spawn-helper",
+  "prebuilds/linux-arm64/spawn-helper",
+  "build/Release/spawn-helper",
+];
+
+let fixed = 0;
+for (const relative of candidates) {
+  const helperPath = path.join(nodePtyDir, relative);
+  let stats;
+  try {
+    stats = fs.statSync(helperPath);
+  } catch {
+    continue;
+  }
+  if (!stats.isFile()) {
+    continue;
+  }
+  if ((stats.mode & 0o111) !== 0) {
+    continue;
+  }
+  try {
+    fs.chmodSync(helperPath, stats.mode | 0o755);
+    fixed += 1;
+  } catch (error) {
+    console.warn(
+      `[cli-wechat-bridge] Could not make node-pty spawn-helper executable: ${helperPath}\n` +
+        `  ${error instanceof Error ? error.message : String(error)}\n` +
+        "  PTY mode may be unavailable; run --doctor for details.",
+    );
+  }
+}
+
+if (fixed > 0) {
+  console.log(
+    `[cli-wechat-bridge] Restored executable bit on ${fixed} node-pty spawn-helper binary(ies).`,
+  );
+}


### PR DESCRIPTION
## 问题

在 macOS（应该也包括 Linux）上，全局安装后用 `wechat-claude-start` 启动 Claude 适配器会立即报错：

```text
[claude-companion] Connected to bridge ...
Warning: no stdin data received in 3s, proceeding without it.
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

而且 `wechat-daemon --doctor` 显示 `node-pty: ✓ loaded`，看起来一切正常，很有迷惑性。

## 根因

`node-pty@1.1.0` 的发布包里，预编译的 `spawn-helper` 二进制权限是 `0644`（缺执行位）。可直接验证：

```console
$ npm pack node-pty@1.1.0 && tar tvf node-pty-1.1.0.tgz | grep spawn-helper
-rw-r--r--  ... package/prebuilds/darwin-arm64/spawn-helper
-rw-r--r--  ... package/prebuilds/darwin-x64/spawn-helper
```

因此 node-pty fork PTY 时 `posix_spawnp` 失败（`posix_spawnp failed`），bridge 回退到非 PTY 模式。Claude 适配器在回退模式下被 Claude CLI 当成管道输入 → 进入 `--print` 非交互模式 → 没有 stdin 数据 → 报上面的错。

`--doctor` 之所以仍显示绿色，是因为它只检查 `import('node-pty')` 能否加载，并不检查能否真正 fork（`src/utils/doctor.ts`）。

## 修复

新增 `scripts/ensure-node-pty-permissions.mjs` 并挂到 `postinstall`：安装后自动为各平台的 `spawn-helper` 补回执行位。脚本是幂等的，且任何异常都不会让安装失败（Windows 直接跳过）。

同时在 `docs/troubleshooting.md` 的 PTY 章节补充了该症状、`posix_spawnp` 关键词与手动 `chmod +x` 兜底方法（应对 `--ignore-scripts` 安装的情况）。

## 验证

```console
$ chmod 644 node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper   # 复现
$ npm run postinstall
[cli-wechat-bridge] Restored executable bit on 2 node-pty spawn-helper binary(ies).
$ npm run postinstall   # 幂等，二次运行无输出
```

修复后 forkpty 实测可正常 spawn，Claude 适配器进入真正的 PTY 交互模式，`--print` 报错消失。

环境：macOS（Apple Silicon, darwin-arm64），Node v24.16.0，node-pty 1.1.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)