### PR TITLE
fix: resolve "claude.cmd is not recognized as an internal or external command" issue caused by spaces in the Claude CLI installation path on Windows. feat: surport muilt claude code terminal(only surport claude code)

### DIFF
--- a/bin/wechat-claude-multi-start.mjs
+++ b/bin/wechat-claude-multi-start.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// Generic launcher: wechat-claude-multi-start <N> [...args]
+//   Example: wechat-claude-multi-start 5 --cwd D:\project-A
+//   Equivalent to: wechat-claude-start --instance 5 --cwd D:\project-A
+//
+// WeChat side: /claude@5 routes messages to this instance.
+
+import { runJsEntry } from "./_run-entry.mjs";
+
+const args = process.argv.slice(2);
+const instance = args[0];
+const rest = args.slice(1);
+
+if (!instance || !/^\d+$/.test(instance)) {
+  process.stderr.write(
+    "Usage: wechat-claude-multi-start <instance> [--cwd <path>] [...claude args]\n" +
+    "  Example: wechat-claude-multi-start 1 --cwd D:\\project-A\n" +
+    "  Example: wechat-claude-multi-start 5\n\n" +
+    "Creates a numbered Claude slot that can be addressed via /claude@<instance> in WeChat.\n",
+  );
+  process.exit(1);
+}
+
+// Strip the instance arg so runJsEntry doesn't forward it as a raw CLI arg.
+// runJsEntry appends process.argv.slice(2) after extraArgs, so we must remove
+// the instance number from argv to avoid it reaching Claude Code as garbage input.
+process.argv = [process.argv[0], process.argv[1], ...rest];
+
+runJsEntry("dist/companion/local-companion-start.js", [
+  "--adapter", "claude",
+  "--instance", instance,
+]);

--- a/bin/wechat-claude-multi.mjs
+++ b/bin/wechat-claude-multi.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+// Generic launcher: wechat-claude-multi <N> [...args]
+//   Example: wechat-claude-multi 5 --cwd D:\project-A
+//   Equivalent to: wechat-claude --instance 5 --cwd D:\project-A
+
+import { runJsEntry } from "./_run-entry.mjs";
+
+const args = process.argv.slice(2);
+const instance = args[0];
+const rest = args.slice(1);
+
+if (!instance || !/^\d+$/.test(instance)) {
+  process.stderr.write(
+    "Usage: wechat-claude-multi <instance> [--cwd <path>] [...claude args]\n" +
+    "  Example: wechat-claude-multi 1 --cwd D:\\project-A\n" +
+    "  Example: wechat-claude-multi 5\n\n" +
+    "Connects to a numbered Claude slot managed by wechat-daemon.\n",
+  );
+  process.exit(1);
+}
+
+// Strip the instance arg so runJsEntry doesn't forward it as a raw CLI arg.
+process.argv = [process.argv[0], process.argv[1], ...rest];
+
+runJsEntry("dist/companion/local-companion.js", [
+  "--adapter", "claude",
+  "--instance", instance,
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "cli-wechat-bridge",
       "version": "1.1.1",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -23,6 +24,10 @@
         "wechat-check-update": "bin/wechat-check-update.mjs",
         "wechat-claude": "bin/wechat-claude.mjs",
         "wechat-claude-start": "bin/wechat-claude-start.mjs",
+        "wechat-claude1": "bin/wechat-claude1.mjs",
+        "wechat-claude1-start": "bin/wechat-claude1-start.mjs",
+        "wechat-claude2": "bin/wechat-claude2.mjs",
+        "wechat-claude2-start": "bin/wechat-claude2-start.mjs",
         "wechat-codex": "bin/wechat-codex.mjs",
         "wechat-codex-start": "bin/wechat-codex-start.mjs",
         "wechat-daemon": "bin/wechat-daemon.mjs",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "wechat-codex-start": "bin/wechat-codex-start.mjs",
     "wechat-claude": "bin/wechat-claude.mjs",
     "wechat-claude-start": "bin/wechat-claude-start.mjs",
+    "wechat-claude-multi": "bin/wechat-claude-multi.mjs",
+    "wechat-claude-multi-start": "bin/wechat-claude-multi-start.mjs",
     "wechat-bridge-claude": "bin/wechat-bridge-claude.mjs",
     "wechat-bridge-shell": "bin/wechat-bridge-shell.mjs",
     "wechat-bridge-opencode": "bin/wechat-bridge-opencode.mjs",

--- a/src/bridge/bridge-adapters.core.ts
+++ b/src/bridge/bridge-adapters.core.ts
@@ -180,6 +180,7 @@ export class LocalCompanionProxyAdapter implements BridgeAdapter {
           runtimeKind: "legacy_adapter",
           instanceId: `${process.pid}-${Date.now().toString(36)}`,
           kind: this.options.kind,
+          instance: this.options.instance,
           port: address.port,
           token: buildLocalCompanionToken(),
           cwd: this.options.cwd,

--- a/src/bridge/bridge-adapters.core.ts
+++ b/src/bridge/bridge-adapters.core.ts
@@ -1,4 +1,5 @@
 ﻿import net from "node:net";
+import path from "node:path";
 import { spawn as spawnPty } from "node-pty";
 import type { IPty } from "node-pty";
 import { t } from "../i18n/index.ts";
@@ -49,6 +50,43 @@ const {
   resolveSpawnTarget,
   spawnFallbackProcess,
 } = shared;
+
+/**
+ * On Windows, node-pty (ConPTY) uses CreateProcess which can execute .cmd/.bat
+ * files directly — no need for the cmd.exe wrapper that resolveSpawnTarget adds
+ * for child_process.spawn compatibility.  The wrapper causes double-quoting when
+ * the script path contains spaces: node-pty quotes the already-quoted path,
+ * making cmd.exe treat the literal quotes as part of the filename.
+ */
+function unwrapCmdExeForPty(rawTarget: SpawnTarget): SpawnTarget {
+  if (process.platform !== "win32") {
+    return rawTarget;
+  }
+
+  const fileName = path.basename(rawTarget.file).toLowerCase();
+  if (fileName !== "cmd.exe") {
+    return rawTarget;
+  }
+
+  const args = rawTarget.args;
+  if (args.length < 4 || args[0] !== "/d" || args[1] !== "/s" || args[2] !== "/c") {
+    return rawTarget;
+  }
+
+  // Strip surrounding double-quotes from the /c argument to recover the
+  // actual script path.  quoteForCmd wraps paths containing spaces in
+  // double-quotes, so we reverse that here.
+  const commandLine = args[3] ?? "";
+  const actualScript = commandLine.replace(/^"(.*)"$/s, "$1");
+
+  // Remaining args beyond the /c handler (args[4..]) are extra arguments
+  // that were passed through wrapWithCmdExe; forward them as the new target's
+  // args so they stay prepended before buildSpawnArgs().
+  return {
+    file: actualScript,
+    args: args.slice(4),
+  };
+}
 
 export class LocalCompanionProxyAdapter implements BridgeAdapter {
   private readonly options: AdapterOptions;
@@ -690,7 +728,8 @@ export abstract class AbstractPtyAdapter implements BridgeAdapter {
 
     let spawnTarget: SpawnTarget | null = null;
     try {
-      spawnTarget = resolveSpawnTarget(this.options.command, this.options.kind);
+      const rawTarget = resolveSpawnTarget(this.options.command, this.options.kind);
+      spawnTarget = unwrapCmdExeForPty(rawTarget);
       const env = this.buildEnv();
       const spawnArgs = [...spawnTarget.args, ...this.buildSpawnArgs()];
 

--- a/src/bridge/bridge-adapters.shared.ts
+++ b/src/bridge/bridge-adapters.shared.ts
@@ -56,6 +56,7 @@ export type AdapterOptions = {
   kind: BridgeAdapterKind;
   command: string;
   cwd: string;
+  instance?: number;
   profile?: string;
   extraCliArgs?: string[];
   lifecycle?: BridgeLifecycleMode;

--- a/src/bridge/bridge-state.ts
+++ b/src/bridge/bridge-state.ts
@@ -6,6 +6,7 @@ import {
   appendBoundedLog,
   ensureWorkspaceChannelDir,
   ensureChannelDataDir,
+  getBridgeLockFile,
 } from "../wechat/channel-config.ts";
 import type {
   BridgeAdapterKind,
@@ -21,6 +22,7 @@ type BridgeStateOptions = {
   adapter: BridgeAdapterKind;
   command: string;
   cwd: string;
+  instance?: number;
   profile?: string;
   lifecycle: BridgeLifecycleMode;
   sessionStartMode?: BridgeSessionStartMode;
@@ -32,6 +34,7 @@ export type BridgeLockPayload = {
   parentPid: number;
   instanceId: string;
   adapter: BridgeAdapterKind;
+  instance?: number;
   command: string;
   cwd: string;
   startedAt: string;
@@ -156,6 +159,9 @@ export function normalizeBridgeLockPayload(value: unknown): BridgeLockPayload | 
     parentPid: typeof record.parentPid === "number" ? record.parentPid : 0,
     instanceId: record.instanceId,
     adapter,
+    instance: typeof record.instance === "number" && record.instance > 0
+      ? record.instance
+      : undefined,
     command: record.command,
     cwd: record.cwd,
     startedAt: record.startedAt,
@@ -164,12 +170,13 @@ export function normalizeBridgeLockPayload(value: unknown): BridgeLockPayload | 
   };
 }
 
-export function readBridgeLockFile(): BridgeLockPayload | null {
+export function readBridgeLockFile(instance?: number): BridgeLockPayload | null {
   try {
-    if (!fs.existsSync(BRIDGE_LOCK_FILE)) {
+    const lockFile = getBridgeLockFile(instance);
+    if (!fs.existsSync(lockFile)) {
       return null;
     }
-    return normalizeBridgeLockPayload(JSON.parse(fs.readFileSync(BRIDGE_LOCK_FILE, "utf-8")));
+    return normalizeBridgeLockPayload(JSON.parse(fs.readFileSync(lockFile, "utf-8")));
   } catch {
     return null;
   }
@@ -278,6 +285,7 @@ export class BridgeStateStore {
       parentPid: process.ppid,
       instanceId: this.instanceId,
       adapter: options.adapter,
+      instance: options.instance,
       command: options.command,
       cwd: options.cwd,
       startedAt: new Date(this.bridgeStartedAtMs).toISOString(),
@@ -431,9 +439,10 @@ export class BridgeStateStore {
 
   releaseLock(): void {
     try {
-      const currentLock = readBridgeLockFile();
+      const lockFile = getBridgeLockFile(this.lockPayload.instance);
+      const currentLock = readBridgeLockFile(this.lockPayload.instance);
       if (currentLock?.pid === process.pid) {
-        fs.rmSync(BRIDGE_LOCK_FILE, { force: true });
+        fs.rmSync(lockFile, { force: true });
       }
     } catch {
       // Best effort cleanup.
@@ -455,7 +464,8 @@ export class BridgeStateStore {
   }
 
   private acquireLock(): void {
-    const existing = readBridgeLockFile();
+    const lockFile = getBridgeLockFile(this.lockPayload.instance);
+    const existing = readBridgeLockFile(this.lockPayload.instance);
     if (
       existing &&
       existing.pid !== process.pid &&
@@ -484,7 +494,7 @@ export class BridgeStateStore {
       }
     }
 
-    this.writeAtomicJsonFile(BRIDGE_LOCK_FILE, this.lockPayload);
+    this.writeAtomicJsonFile(lockFile, this.lockPayload);
   }
 
   verifyRuntimeOwnership(): BridgeRuntimeOwnership {
@@ -496,7 +506,7 @@ export class BridgeStateStore {
         typeof workspaceState?.instanceId === "string"
           ? workspaceState.instanceId
           : undefined,
-      lock: readBridgeLockFile(),
+      lock: readBridgeLockFile(this.lockPayload.instance),
     });
 
     if (!ownership.ok) {
@@ -508,7 +518,8 @@ export class BridgeStateStore {
     }
 
     if (ownership.rehydratedLock) {
-      this.writeAtomicJsonFile(BRIDGE_LOCK_FILE, this.lockPayload);
+      const lockFile = getBridgeLockFile(this.lockPayload.instance);
+      this.writeAtomicJsonFile(lockFile, this.lockPayload);
     }
 
     return ownership;

--- a/src/bridge/wechat-bridge.ts
+++ b/src/bridge/wechat-bridge.ts
@@ -79,6 +79,7 @@ type BridgeCliOptions = {
   adapter: BridgeAdapterKind;
   command: string;
   cwd: string;
+  instance?: number;
   profile?: string;
   lifecycle: BridgeLifecycleMode;
   sessionStartMode: BridgeSessionStartMode;
@@ -218,6 +219,47 @@ function formatWechatSendRetryLogEntry(params: {
   return `wechat_send_retry: context=${params.context} recipient=${params.recipientId} attempt=${params.attempt} delay_ms=${params.delayMs} error=${truncatePreview(describeWechatTransportError(params.error), 400)}`;
 }
 
+/** Prefix user-facing WeChat messages with an instance label for multi-instance bridges. */
+function prefixInstanceMessage(text: string, instance?: number): string {
+  if (!instance) return text;
+  const trimmed = text.trim();
+  return trimmed ? `[claude@${instance}]\n${trimmed}` : `[claude@${instance}]`;
+}
+
+/**
+ * Extract the first text line from a raw WeChat message for routing decisions.
+ * Must run BEFORE claiming so messages for other instances aren't locked.
+ */
+function quickExtractText(raw: { item_list?: Array<{ type?: number; text_item?: { text?: string } }> }): string {
+  if (!raw.item_list) return "";
+  for (const item of raw.item_list) {
+    if (item.type === 1 && item.text_item?.text) return item.text_item.text;
+  }
+  return "";
+}
+
+/** Instance-routing regex: /claude@N at the start of a message (possibly with whitespace after). */
+const INSTANCE_ROUTE_RE = /^\/claude@(\d+)(?:\s|$)/;
+
+/**
+ * Determines whether an instance-specific bridge should process (claim) a raw
+ * WeChat message.  Messages explicitly routed to a different instance are
+ * skipped so the correct instance can claim them.
+ */
+function shouldInstanceBridgeProcessMessage(
+  raw: { item_list?: Array<{ type?: number; text_item?: { text?: string } }> },
+  instance: number,
+): boolean {
+  const text = quickExtractText(raw).trim();
+  const match = text.match(INSTANCE_ROUTE_RE);
+  if (match) {
+    // Message has explicit routing — only process if it matches our instance
+    return parseInt(match[1], 10) === instance;
+  }
+  // No routing prefix — any instance can process (backward compatible)
+  return true;
+}
+
 export function isRetryableWechatSendError(error: unknown): boolean {
   if (isWechatContextTokenStaleError(error)) {
     return false;
@@ -325,6 +367,7 @@ export function parseCliArgs(argv: string[]): BridgeCliOptions {
   let adapter: BridgeAdapterKind | null = null;
   let commandOverride: string | undefined;
   let cwd = process.cwd();
+  let instance: number | undefined;
   let profile: string | undefined;
   let lifecycle: BridgeLifecycleMode = "persistent";
   let sessionStartMode: BridgeSessionStartMode = "restore";
@@ -353,6 +396,19 @@ export function parseCliArgs(argv: string[]): BridgeCliOptions {
           throw new Error("--cwd requires a value");
         }
         cwd = path.resolve(next);
+        i += 1;
+        break;
+      case "--instance":
+        if (!next) {
+          throw new Error("--instance requires a value");
+        }
+        {
+          const parsed = Number(next);
+          if (!Number.isInteger(parsed) || parsed < 0) {
+            throw new Error("--instance must be a non-negative integer");
+          }
+          instance = parsed > 0 ? parsed : undefined;
+        }
         i += 1;
         break;
       case "--profile":
@@ -397,6 +453,7 @@ export function parseCliArgs(argv: string[]): BridgeCliOptions {
     adapter,
     command: commandOverride ?? defaultCommand,
     cwd,
+    instance,
     profile,
     lifecycle,
     sessionStartMode,
@@ -640,7 +697,7 @@ async function main(): Promise<void> {
   };
 
   const outputBatcher = new OutputBatcher(async (text) => {
-    await queueWechatMessage(stateStore.getState().authorizedUserId, text);
+    await queueWechatMessage(stateStore.getState().authorizedUserId, prefixInstanceMessage(text, options.instance));
   });
   const maybeDrainDeferredInboundMessages = async (): Promise<void> => {
     if (drainingDeferredInboundMessages || !ensureRuntimeOwnership()) {
@@ -891,6 +948,10 @@ async function main(): Promise<void> {
         pollResult = await transport.pollMessages({
           timeoutMs: DEFAULT_LONG_POLL_TIMEOUT_MS,
           minCreatedAtMs: stateStore.getState().bridgeStartedAtMs - MESSAGE_START_GRACE_MS,
+          shouldProcess:
+            options.instance
+              ? (raw) => shouldInstanceBridgeProcessMessage(raw, options.instance!)
+              : undefined,
         });
       } catch (err) {
         const classification = classifyWechatTransportError(err);
@@ -1129,7 +1190,7 @@ function wireAdapterEvents(params: {
               sendText: async (text) => {
                 const sent = await queueWechatMessage(
                   authorizedUserId,
-                  text,
+                  prefixInstanceMessage(text, options.instance),
                   "final_reply",
                 );
                 if (sent) {
@@ -1378,6 +1439,15 @@ async function handleInboundMessage(params: {
     deferInboundMessage,
   } = params;
   const state = stateStore.getState();
+
+  // Strip instance routing prefix for instance-specific bridges.
+  // The transport filter already ensured this message is for us.
+  if (options.instance) {
+    const stripped = message.text.replace(INSTANCE_ROUTE_RE, "").trim();
+    if (stripped !== message.text) {
+      message = { ...message, text: stripped };
+    }
+  }
 
   if (message.senderId !== state.authorizedUserId) {
     await queueWechatMessage(

--- a/src/companion/local-companion-link.ts
+++ b/src/companion/local-companion-link.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import type net from "node:net";
 
 import {
@@ -41,10 +42,12 @@ export type LocalCompanionEndpoint = LocalClientEndpoint;
 
 type EndpointReadOptions = {
   adapter?: BridgeAdapterKind;
+  instance?: number;
 };
 
 type EndpointWriteOptions = {
   writeLegacy?: boolean;
+  instance?: number;
 };
 
 export type LocalCompanionMessage =
@@ -195,8 +198,9 @@ export function writeLocalCompanionEndpoint(
     ...serializeEndpoint(endpoint),
   };
 
+  const instance = options.instance ?? endpoint.instance;
   fs.writeFileSync(
-    getWorkspaceAdapterEndpointFile(endpoint.cwd, endpoint.kind),
+    getWorkspaceAdapterEndpointFile(endpoint.cwd, endpoint.kind, instance),
     JSON.stringify(payload, null, 2),
     "utf8",
   );
@@ -213,7 +217,7 @@ export function readLocalCompanionEndpoint(
     const { endpointFile } = getWorkspaceChannelPaths(cwd);
     if (options.adapter) {
       const scoped = readEndpointFile(
-        getWorkspaceAdapterEndpointFile(cwd, options.adapter),
+        getWorkspaceAdapterEndpointFile(cwd, options.adapter, options.instance),
       );
       if (scoped) {
         return scoped;
@@ -233,16 +237,84 @@ export function clearLocalCompanionEndpoint(
   options: EndpointReadOptions = {},
 ): void {
   try {
-    const { endpointFile } = getWorkspaceChannelPaths(cwd);
-    const files = options.adapter
-      ? [getWorkspaceAdapterEndpointFile(cwd, options.adapter), endpointFile]
-      : [
-          endpointFile,
-          getWorkspaceAdapterEndpointFile(cwd, "codex"),
-          getWorkspaceAdapterEndpointFile(cwd, "claude"),
-          getWorkspaceAdapterEndpointFile(cwd, "opencode"),
-          getWorkspaceAdapterEndpointFile(cwd, "shell"),
-        ];
+    const { workspaceDir, endpointFile: legacyFile } = getWorkspaceChannelPaths(cwd);
+    if (options.adapter) {
+      // When clearing by adapter with a specific instance, only clear that
+      // instance file.  When clearing without an instance, remove all files
+      // matching the adapter prefix (including instance-specific ones) and
+      // the legacy endpoint file.
+      if (options.instance !== undefined && options.instance > 0) {
+        const filePath = getWorkspaceAdapterEndpointFile(cwd, options.adapter, options.instance);
+        if (fs.existsSync(filePath)) {
+          const endpoint = readEndpointFile(filePath);
+          if (!instanceId || !endpoint || endpoint.instanceId === instanceId) {
+            fs.rmSync(filePath, { force: true });
+          }
+        }
+      } else {
+        // Clear all files matching this adapter prefix (e.g. claude*, codex*, opencode*)
+        let entries: fs.Dirent[];
+        try {
+          entries = fs.readdirSync(workspaceDir, { withFileTypes: true });
+        } catch {
+          entries = [];
+        }
+        for (const entry of entries) {
+          if (
+            entry.isFile() &&
+            entry.name.startsWith(`${options.adapter}-`) &&
+            entry.name.endsWith("-companion-endpoint.json")
+          ) {
+            const filePath = path.join(workspaceDir, entry.name);
+            if (!instanceId) {
+              fs.rmSync(filePath, { force: true });
+            } else {
+              const endpoint = readEndpointFile(filePath);
+              if (!endpoint || endpoint.instanceId === instanceId) {
+                fs.rmSync(filePath, { force: true });
+              }
+            }
+          }
+          // Also match instance-specific files: claude@1-companion-endpoint.json
+          if (
+            entry.isFile() &&
+            entry.name.startsWith(`${options.adapter}@`) &&
+            entry.name.endsWith("-companion-endpoint.json")
+          ) {
+            const filePath = path.join(workspaceDir, entry.name);
+            if (!instanceId) {
+              fs.rmSync(filePath, { force: true });
+            } else {
+              const endpoint = readEndpointFile(filePath);
+              if (!endpoint || endpoint.instanceId === instanceId) {
+                fs.rmSync(filePath, { force: true });
+              }
+            }
+          }
+        }
+        // Also clear the legacy endpoint file
+        if (fs.existsSync(legacyFile)) {
+          if (!instanceId) {
+            fs.rmSync(legacyFile, { force: true });
+          } else {
+            const endpoint = readEndpointFile(legacyFile);
+            if (!endpoint || endpoint.instanceId === instanceId) {
+              fs.rmSync(legacyFile, { force: true });
+            }
+          }
+        }
+      }
+      return;
+    }
+
+    // No adapter specified: clear all endpoint files.
+    const files = [
+      legacyFile,
+      getWorkspaceAdapterEndpointFile(cwd, "codex"),
+      getWorkspaceAdapterEndpointFile(cwd, "claude"),
+      getWorkspaceAdapterEndpointFile(cwd, "opencode"),
+      getWorkspaceAdapterEndpointFile(cwd, "shell"),
+    ];
 
     for (const filePath of files) {
       if (!fs.existsSync(filePath)) {

--- a/src/companion/local-companion-start.ts
+++ b/src/companion/local-companion-start.ts
@@ -38,6 +38,7 @@ type LocalCompanionLaunchAdapter = Exclude<BridgeAdapterKind, "shell">;
 type LocalCompanionStartCliOptions = {
   adapter: LocalCompanionLaunchAdapter;
   cwd: string;
+  instance?: number;
   profile?: string;
   timeoutMs: number;
   sessionStartMode: BridgeSessionStartMode;
@@ -196,6 +197,7 @@ export function decideLaunchAction(
 export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
   let adapter: LocalCompanionLaunchAdapter = DEFAULT_ADAPTER;
   let cwd = process.cwd();
+  let instance: number | undefined;
   let profile: string | undefined;
   let timeoutMs = DEFAULT_WAIT_TIMEOUT_MS;
   const cliArgs: string[] = [];
@@ -210,14 +212,15 @@ export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
     if (arg === "--help" || arg === "-h") {
       process.stdout.write(
         [
-          "Usage: wechat-codex-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [...codex args]",
-          "       wechat-claude-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [...claude args]",
-          "       wechat-opencode-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [...opencode args]",
-          "       local-companion-start [--adapter <codex|claude|opencode>] [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [...cli args]",
+          "Usage: wechat-codex-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [--instance <N>] [...codex args]",
+          "       wechat-claude-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [--instance <N>] [...claude args]",
+          "       wechat-opencode-start [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [--instance <N>] [...opencode args]",
+          "       local-companion-start [--adapter <codex|claude|opencode>] [--cwd <path>] [--profile <name-or-path>] [--timeout-ms <ms>] [--instance <N>] [...cli args]",
           "",
           "Starts a bridge for the current directory, waits for the local endpoint, then opens the visible companion or panel.",
           "Claude and OpenCode launchers start a fresh CLI session by default.",
           "All adapters are companion-bound: closing the companion/panel also stops the bridge.",
+          "Use --instance <N> to start a numbered instance that can be addressed via /claude@N in WeChat.",
           "Unknown arguments are forwarded to the visible CLI client.",
           "",
         ].join("\n"),
@@ -239,6 +242,19 @@ export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
         throw new Error("--cwd requires a value");
       }
       cwd = path.resolve(next);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--instance") {
+      if (!next) {
+        throw new Error("--instance requires a value");
+      }
+      const parsed = Number(next);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error("--instance must be a non-negative integer");
+      }
+      instance = parsed > 0 ? parsed : undefined;
       i += 1;
       continue;
     }
@@ -271,6 +287,7 @@ export function parseCliArgs(argv: string[]): LocalCompanionStartCliOptions {
   return {
     adapter,
     cwd,
+    instance,
     profile,
     timeoutMs,
     sessionStartMode: defaultSessionStartMode(adapter),
@@ -414,6 +431,10 @@ export function buildBackgroundBridgeArgs(
     lifecycle,
   );
 
+  if (options.instance && options.instance > 0) {
+    args.push("--instance", String(options.instance));
+  }
+
   if (options.sessionStartMode !== "restore") {
     args.push("--session-start-mode", options.sessionStartMode);
   }
@@ -478,7 +499,7 @@ async function ensureBridgeReady(
   // leftover endpoint.  The bridge (WeChat transport) may have crashed while
   // the opencode server kept running.  Starting only the panel would leave no
   // bridge to poll WeChat messages.
-  const lock = readBridgeLockFile();
+  const lock = readBridgeLockFile(options.instance);
   const lockProcessAlive = lock ? isPidAlive(lock.pid) : false;
   if (!lock || !lockProcessAlive) {
     if (lock && !lockProcessAlive) {
@@ -560,15 +581,17 @@ export async function tryDelegateToDaemon(
     return false;
   }
 
-  if (!isSameWorkspaceCwd(endpoint.cwd, options.cwd)) {
+  // Instance-specific slots are allowed to have their own CWD.
+  if (!options.instance && !isSameWorkspaceCwd(endpoint.cwd, options.cwd)) {
     throw new Error(
-      `wechat-daemon is running for ${endpoint.cwd}. This launcher requested ${options.cwd}; v1 daemon switching is limited to its startup cwd.`,
+      `wechat-daemon is running for ${endpoint.cwd}. This launcher requested ${options.cwd}. Use --instance <N> for per-directory slots.`,
     );
   }
 
   const response: DaemonResponse = await sendRequest(endpoint, {
     command: "ensure_slot",
     adapter: options.adapter,
+    instance: options.instance,
     cwd: options.cwd,
     profile: options.profile,
     cliArgs: options.cliArgs,

--- a/src/companion/local-companion.ts
+++ b/src/companion/local-companion.ts
@@ -28,6 +28,7 @@ function log(adapter: string, message: string): void {
 export type LocalCompanionCliOptions = {
   adapter: "codex" | "claude" | "opencode";
   cwd: string;
+  instance?: number;
   sessionStartMode?: BridgeSessionStartMode;
   cliArgs: string[];
 };
@@ -35,6 +36,7 @@ export type LocalCompanionCliOptions = {
 function parseCliArgs(argv: string[]): LocalCompanionCliOptions {
   let adapter: "codex" | "claude" | "opencode" | null = null;
   let cwd = process.cwd();
+  let instance: number | undefined;
   let sessionStartMode: BridgeSessionStartMode = "restore";
   const cliArgs: string[] = [];
 
@@ -48,9 +50,10 @@ function parseCliArgs(argv: string[]): LocalCompanionCliOptions {
     if (arg === "--help" || arg === "-h") {
       process.stdout.write(
         [
-          "Usage: local-companion --adapter <codex|claude|opencode> [--cwd <path>] [...cli args]",
+          "Usage: local-companion --adapter <codex|claude|opencode> [--cwd <path>] [--instance <N>] [...cli args]",
           "",
           'Starts the visible local companion and connects it to the matching running bridge for the current directory.',
+          "Use --instance <N> to connect to a numbered instance slot.",
           "Unknown arguments are forwarded to the visible CLI client.",
           "",
         ].join("\n"),
@@ -76,6 +79,19 @@ function parseCliArgs(argv: string[]): LocalCompanionCliOptions {
       continue;
     }
 
+    if (arg === "--instance") {
+      if (!next) {
+        throw new Error("--instance requires a value");
+      }
+      const parsed = Number(next);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error("--instance must be a non-negative integer");
+      }
+      instance = parsed > 0 ? parsed : undefined;
+      i += 1;
+      continue;
+    }
+
     if (arg === "--session-start-mode") {
       if (!next || !["restore", "new"].includes(next)) {
         throw new Error(`Invalid session start mode: ${next ?? "(missing)"}`);
@@ -92,7 +108,7 @@ function parseCliArgs(argv: string[]): LocalCompanionCliOptions {
     throw new Error("Missing required --adapter <codex|claude|opencode>");
   }
 
-  return { adapter, cwd, sessionStartMode, cliArgs };
+  return { adapter, cwd, instance, sessionStartMode, cliArgs };
 }
 
 function delay(ms: number): Promise<void> {
@@ -107,10 +123,12 @@ function readMatchingEndpoint(
 ): LocalCompanionEndpoint {
   const endpoint = readLocalCompanionEndpoint(options.cwd, {
     adapter: options.adapter,
+    instance: options.instance,
   });
   if (!endpoint || endpoint.kind !== options.adapter) {
+    const instanceHint = options.instance ? `@${options.instance}` : "";
     throw new Error(
-      `No active ${options.adapter} bridge endpoint was found for ${options.cwd}. Start "wechat-bridge-${options.adapter}" in that directory first.`,
+      `No active ${options.adapter}${instanceHint} bridge endpoint was found for ${options.cwd}. Start "wechat-bridge-${options.adapter}" in that directory first.`,
     );
   }
 

--- a/src/daemon/daemon-link.ts
+++ b/src/daemon/daemon-link.ts
@@ -8,8 +8,28 @@ import {
 } from "../wechat/channel-config.ts";
 import type { BridgeSessionStartMode } from "../bridge/bridge-types.ts";
 
-export const DAEMON_PROTOCOL_VERSION = 1;
+export const DAEMON_PROTOCOL_VERSION = 2;
 export type DaemonAdapterKind = "codex" | "claude" | "opencode";
+
+/** Build a slot map key from adapter kind and optional instance number.
+ *  `buildSlotKey("claude")` → `"claude"`
+ *  `buildSlotKey("claude", 1)` → `"claude@1"` */
+export function buildSlotKey(adapter: DaemonAdapterKind, instance?: number): string {
+  if (instance !== undefined && instance > 0) {
+    return `${adapter}@${instance}`;
+  }
+  return adapter;
+}
+
+/** Parse a slot map key back into adapter kind and optional instance number.
+ *  `parseSlotKey("claude@1")` → `{ adapter: "claude", instance: 1 }`
+ *  `parseSlotKey("claude")` → `{ adapter: "claude" }` */
+export function parseSlotKey(key: string): { adapter: DaemonAdapterKind; instance?: number } | null {
+  const match = key.match(/^(codex|claude|opencode)(?:@(\d+))?$/);
+  if (!match) return null;
+  const instance = match[2] ? parseInt(match[2], 10) : undefined;
+  return { adapter: match[1] as DaemonAdapterKind, instance };
+}
 
 export type DaemonEndpoint = {
   protocolVersion: number;
@@ -22,6 +42,7 @@ export type DaemonEndpoint = {
 
 export type DaemonSlotSummary = {
   adapter: DaemonAdapterKind;
+  instance?: number;
   status: string;
   cwd: string;
   companionPid?: number;
@@ -32,6 +53,7 @@ export type DaemonSlotSummary = {
 export type DaemonStatus = {
   cwd: string;
   activeAdapter?: DaemonAdapterKind;
+  activeSlotKey?: string;
   startedAt: string;
   slots: DaemonSlotSummary[];
 };
@@ -40,6 +62,7 @@ export type DaemonRequest =
   | {
       command: "ensure_slot";
       adapter: DaemonAdapterKind;
+      instance?: number;
       cwd: string;
       profile?: string;
       cliArgs?: string[];
@@ -50,6 +73,8 @@ export type DaemonRequest =
   | {
       command: "switch_adapter";
       adapter: DaemonAdapterKind;
+      instance?: number;
+      cwd?: string;
       profile?: string;
       cliArgs?: string[];
       openVisible?: boolean;

--- a/src/daemon/wechat-daemon.ts
+++ b/src/daemon/wechat-daemon.ts
@@ -69,6 +69,7 @@ import {
   BRIDGE_LOG_FILE,
   appendBoundedLog,
   ensureChannelDataDir,
+  getBridgeLockFile,
   migrateLegacyChannelFiles,
 } from "../wechat/channel-config.ts";
 import { ensureWechatCredentials } from "../wechat/setup.ts";
@@ -103,9 +104,11 @@ import {
 import {
   attachDaemonRequestListener,
   buildDaemonToken,
+  buildSlotKey,
   clearDaemonEndpoint,
   DAEMON_PROTOCOL_VERSION,
   isPidAlive,
+  parseSlotKey,
   readDaemonEndpoint,
   sendDaemonRequest,
   sendDaemonResponse,
@@ -281,18 +284,14 @@ export function parseDaemonCliArgs(argv: string[]): DaemonCliOptions {
   return { cwd, profile, initialAdapter, openVisible };
 }
 
-export function parseDaemonSwitchCommand(text: string): DaemonAdapterKind | null {
+export function parseDaemonSwitchCommand(
+  text: string,
+): { adapter: DaemonAdapterKind; instance?: number } | null {
   const normalized = text.trim().toLowerCase();
-  switch (normalized) {
-    case "/codex":
-      return "codex";
-    case "/claude":
-      return "claude";
-    case "/opencode":
-      return "opencode";
-    default:
-      return null;
-  }
+  const match = normalized.match(/^\/(codex|claude|opencode)(?:@(\d+))?$/);
+  if (!match) return null;
+  const instance = match[2] ? parseInt(match[2], 10) : undefined;
+  return { adapter: match[1] as DaemonAdapterKind, instance };
 }
 
 export function defaultDaemonSessionStartMode(
@@ -359,6 +358,7 @@ function prefixDaemonAdapterMessage(adapter: DaemonAdapterKind, text: string): s
 export function buildVisibleClientLaunchArgs(params: {
   adapter: DaemonAdapterKind;
   cwd: string;
+  instance?: number;
   sessionStartMode?: BridgeSessionStartMode;
   cliArgs?: string[];
 }): string[] {
@@ -384,6 +384,9 @@ export function buildVisibleClientLaunchArgs(params: {
   if (params.adapter !== "codex") {
     args.push("--adapter", params.adapter);
   }
+  if (params.instance && params.instance > 0) {
+    args.push("--instance", String(params.instance));
+  }
   if (params.sessionStartMode && params.sessionStartMode !== "restore") {
     args.push("--session-start-mode", params.sessionStartMode);
   }
@@ -393,12 +396,16 @@ export function buildVisibleClientLaunchArgs(params: {
 
 export function buildWindowsVisibleClientLaunchCommand(params: {
   adapter: DaemonAdapterKind;
+  instance?: number;
   cwd: string;
   args: string[];
 }): string {
+  const title = params.instance
+    ? `wechat-${params.adapter}@${params.instance}`
+    : `wechat-${params.adapter}`;
   return [
     "start",
-    quoteWindowsCommandArg(`wechat-${params.adapter}`),
+    quoteWindowsCommandArg(title),
     "/D",
     quoteWindowsCommandArg(params.cwd),
     quoteWindowsCommandArg(process.execPath),
@@ -450,6 +457,7 @@ function formatLaunchPreview(launch: VisibleClientLaunch): string {
 
 function openVisibleClient(params: {
   adapter: DaemonAdapterKind;
+  instance?: number;
   cwd: string;
   sessionStartMode?: BridgeSessionStartMode;
   cliArgs?: string[];
@@ -463,6 +471,7 @@ function openVisibleClient(params: {
       "/c",
       buildWindowsVisibleClientLaunchCommand({
         adapter: params.adapter,
+        instance: params.instance,
         cwd: params.cwd,
         args,
       }),
@@ -490,7 +499,9 @@ function openVisibleClient(params: {
     };
   }
 
-  const title = `wechat-${params.adapter}`;
+  const title = params.instance
+    ? `wechat-${params.adapter}@${params.instance}`
+    : `wechat-${params.adapter}`;
   const fullArgs = [process.execPath, ...args];
 
   if (process.platform === "darwin") {
@@ -552,8 +563,8 @@ end tell`;
   };
 }
 
-function isVisibleClientAlive(cwd: string, adapter: DaemonAdapterKind): boolean {
-  const endpoint = readLocalCompanionEndpoint(cwd, { adapter });
+function isVisibleClientAlive(cwd: string, adapter: DaemonAdapterKind, instance?: number): boolean {
+  const endpoint = readLocalCompanionEndpoint(cwd, { adapter, instance });
   if (!endpoint?.companionPid) {
     return false;
   }
@@ -561,7 +572,7 @@ function isVisibleClientAlive(cwd: string, adapter: DaemonAdapterKind): boolean 
     return true;
   }
 
-  clearLocalCompanionOccupancy(cwd, endpoint.instanceId, { adapter });
+  clearLocalCompanionOccupancy(cwd, endpoint.instanceId, { adapter, instance });
   return false;
 }
 
@@ -582,11 +593,12 @@ export async function waitForVisibleClientConnection(
   params: {
     cwd: string;
     adapter: DaemonAdapterKind;
+    instance?: number;
     timeoutMs?: number;
     pollMs?: number;
   },
   deps: {
-    isAlive?: (cwd: string, adapter: DaemonAdapterKind) => boolean;
+    isAlive?: (cwd: string, adapter: DaemonAdapterKind, instance?: number) => boolean;
     sleep?: (ms: number) => Promise<void>;
     now?: () => number;
   } = {},
@@ -594,12 +606,13 @@ export async function waitForVisibleClientConnection(
   const timeoutMs = params.timeoutMs ?? VISIBLE_CLIENT_CONNECT_TIMEOUT_MS;
   const pollMs = params.pollMs ?? VISIBLE_CLIENT_CONNECT_POLL_MS;
   const isAlive = deps.isAlive ?? isVisibleClientAlive;
+  const instance = params.instance;
   const sleepFn = deps.sleep ?? sleep;
   const now = deps.now ?? (() => Date.now());
   const deadline = now() + timeoutMs;
 
   while (true) {
-    if (isAlive(params.cwd, params.adapter)) {
+    if (isAlive(params.cwd, params.adapter, instance)) {
       return true;
     }
 
@@ -676,22 +689,20 @@ export function formatDaemonStatus(status: DaemonStatus): string {
   const lines = [
     "wechat-daemon status",
     `cwd: ${status.cwd}`,
-    `active: ${status.activeAdapter ?? "(none)"}`,
+    `active: ${status.activeSlotKey ?? status.activeAdapter ?? "(none)"}`,
     `started_at: ${status.startedAt}`,
   ];
 
-  for (const adapter of DAEMON_ADAPTERS) {
-    const slot = status.slots.find((entry) => entry.adapter === adapter);
-    if (!slot) {
-      lines.push(`${adapter}: not started`);
-      continue;
-    }
+  for (const slot of status.slots) {
+    const slotLabel = slot.instance
+      ? `${slot.adapter}@${slot.instance}`
+      : slot.adapter;
     const flags = [
       slot.pendingApproval ? "pending_approval" : "",
       slot.pendingUserInput ? "pending_input" : "",
       slot.companionPid ? `companion_pid=${slot.companionPid}` : "",
     ].filter(Boolean);
-    lines.push(`${adapter}: ${slot.status}${flags.length ? ` (${flags.join(", ")})` : ""}`);
+    lines.push(`${slotLabel}: ${slot.status}${flags.length ? ` (${flags.join(", ")})` : ""}`);
   }
 
   return lines.join("\n");
@@ -702,11 +713,11 @@ class WechatDaemon {
   private readonly profile?: string;
   private readonly authorizedUserId: string;
   private readonly transport: WeChatTransport;
-  private readonly slots = new Map<DaemonAdapterKind, DaemonSlot>();
+  private readonly slots = new Map<string, DaemonSlot>();
   private readonly startedAt = new Date().toISOString();
   private readonly bridgeStartedAtMs = Date.now();
   private backlogNoticeSent = false;
-  private activeAdapter: DaemonAdapterKind | null = null;
+  private activeSlotKey: string | null = null;
   takenOverAdapter?: DaemonAdapterKind;
   private textSendChain = Promise.resolve();
   private attachmentSendChain = Promise.resolve();
@@ -787,16 +798,23 @@ class WechatDaemon {
   getStatus(): DaemonStatus {
     return {
       cwd: this.cwd,
-      activeAdapter: this.activeAdapter ?? undefined,
+      activeAdapter: this.activeSlotKey
+        ? parseSlotKey(this.activeSlotKey)?.adapter
+        : undefined,
+      activeSlotKey: this.activeSlotKey ?? undefined,
       startedAt: this.startedAt,
-      slots: Array.from(this.slots.values()).map((slot): DaemonSlotSummary => {
-        const endpoint = readLocalCompanionEndpoint(this.cwd, {
+      slots: Array.from(this.slots.entries()).map(([key, slot]): DaemonSlotSummary => {
+        const parsed = parseSlotKey(key);
+        const slotCwd = slot.runtime.getState().cwd || this.cwd;
+        const endpoint = readLocalCompanionEndpoint(slotCwd, {
           adapter: slot.adapter,
+          instance: parsed?.instance,
         });
         return {
           adapter: slot.adapter,
+          instance: parsed?.instance,
           status: slot.runtime.getState().status,
-          cwd: this.cwd,
+          cwd: slotCwd,
           companionPid: endpoint?.companionPid,
           pendingApproval: slot.pendingConfirmations.length > 0,
           pendingUserInput: Boolean(slot.pendingUserInput),
@@ -896,7 +914,9 @@ class WechatDaemon {
           await this.queueWechatMessage(
             message.senderId,
             formatUserFacingInboundError({
-              adapter: this.activeAdapter ?? "codex",
+              adapter: this.activeSlotKey
+                ? (parseSlotKey(this.activeSlotKey)?.adapter ?? "codex")
+                : "codex",
               cwd: this.cwd,
               errorText,
               isUserFacingShellRejection,
@@ -959,32 +979,34 @@ class WechatDaemon {
         }, 0);
         return { shuttingDown: true };
       case "ensure_slot":
-        if (!isSameWorkspaceCwd(request.cwd, this.cwd)) {
+      case "switch_adapter": {
+        const slotCwd = request.cwd ?? this.cwd;
+        // For instance-specific slots, skip the strict CWD check.
+        // Plain (non-instance) slots still validate against the daemon cwd
+        // for backward compatibility.
+        if (!request.instance && !isSameWorkspaceCwd(slotCwd, this.cwd)) {
           throw new Error(
-            `wechat-daemon is bound to ${this.cwd}; requested cwd was ${request.cwd}.`,
+            `wechat-daemon is bound to ${this.cwd}; requested cwd was ${slotCwd}. Use --instance <N> for per-directory slots.`,
           );
         }
         return await this.ensureSlot(request.adapter, {
+          instance: request.instance,
+          cwd: slotCwd,
           profile: request.profile,
           cliArgs: request.cliArgs,
           openVisible: request.openVisible ?? true,
           sessionStartMode: request.sessionStartMode,
           reuseExistingVisible: request.reuseExistingVisible ?? true,
         });
-      case "switch_adapter":
-        return await this.ensureSlot(request.adapter, {
-          profile: request.profile,
-          cliArgs: request.cliArgs,
-          openVisible: request.openVisible ?? true,
-          sessionStartMode: request.sessionStartMode,
-          reuseExistingVisible: request.reuseExistingVisible ?? true,
-        });
+      }
     }
   }
 
   private async ensureSlot(
     adapter: DaemonAdapterKind,
     options: {
+      instance?: number;
+      cwd?: string;
       profile?: string;
       cliArgs?: string[];
       openVisible?: boolean;
@@ -993,14 +1015,19 @@ class WechatDaemon {
     } = {},
   ): Promise<{
     activeAdapter: DaemonAdapterKind;
+    activeSlotKey: string;
     created: boolean;
     openedVisible: boolean;
     visibleConnected: boolean;
     activated: boolean;
     previousActiveAdapter?: DaemonAdapterKind;
   }> {
-    const previousActiveAdapter = this.activeAdapter ?? undefined;
-    let slot = this.slots.get(adapter);
+    const slotKey = buildSlotKey(adapter, options.instance);
+    const slotCwd = options.cwd ?? this.cwd;
+    const previousActiveAdapter = this.activeSlotKey
+      ? parseSlotKey(this.activeSlotKey)?.adapter
+      : undefined;
+    let slot = this.slots.get(slotKey);
     let created = false;
     if (!slot) {
       const createSessionStartMode =
@@ -1010,15 +1037,17 @@ class WechatDaemon {
         this.takenOverAdapter = undefined;
       }
       slot = await this.createSlot(adapter, {
+        cwd: slotCwd,
+        instance: options.instance,
         profile: options.profile ?? this.profile,
         sessionStartMode: createSessionStartMode,
       });
-      this.slots.set(adapter, slot);
+      this.slots.set(slotKey, slot);
       created = true;
     }
 
     let openedVisible = false;
-    let visibleConnected = isVisibleClientAlive(this.cwd, adapter);
+    let visibleConnected = isVisibleClientAlive(slotCwd, adapter, options.instance);
     const sessionStartMode = resolveDaemonSessionStartMode({
       adapter,
       explicitSessionStartMode: options.sessionStartMode,
@@ -1035,53 +1064,56 @@ class WechatDaemon {
       visibleConnected
     ) {
       await this.startFreshSlotSession(slot);
-      appendDaemonLog(`fresh_session_started: adapter=${adapter} source=start_command`);
+      appendDaemonLog(`fresh_session_started: adapter=${slotKey} source=start_command`);
     }
 
     if (options.openVisible !== false && !visibleConnected) {
       slot.controller.syncLocalClientEndpoint();
       const launch = openVisibleClient({
         adapter,
-        cwd: this.cwd,
+        instance: options.instance,
+        cwd: slotCwd,
         sessionStartMode,
         cliArgs: options.cliArgs,
         onError: (error) => {
           appendDaemonLog(
-            `visible_client_open_error: adapter=${adapter} error=${truncatePreview(error.message, 400)}`,
+            `visible_client_open_error: adapter=${slotKey} error=${truncatePreview(error.message, 400)}`,
           );
         },
       });
       openedVisible = true;
       appendDaemonLog(
-        `visible_client_open_attempt: adapter=${adapter} cwd=${this.cwd} pid=${launch.pid ?? "unknown"} command=${truncatePreview(formatLaunchPreview(launch), 400)}`,
+        `visible_client_open_attempt: adapter=${slotKey} cwd=${slotCwd} pid=${launch.pid ?? "unknown"} command=${truncatePreview(formatLaunchPreview(launch), 400)}`,
       );
       visibleConnected = await waitForVisibleClientConnection({
-        cwd: this.cwd,
+        cwd: slotCwd,
         adapter,
+        instance: options.instance,
       });
       if (visibleConnected) {
-        appendDaemonLog(`visible_client_connected: adapter=${adapter} cwd=${this.cwd}`);
+        appendDaemonLog(`visible_client_connected: adapter=${slotKey} cwd=${slotCwd}`);
       } else {
         log(
-          `${adapter} visible CLI did not connect within ${formatDuration(VISIBLE_CLIENT_CONNECT_TIMEOUT_MS)}. Check ${BRIDGE_LOG_FILE}.`,
+          `${slotKey} visible CLI did not connect within ${formatDuration(VISIBLE_CLIENT_CONNECT_TIMEOUT_MS)}. Check ${BRIDGE_LOG_FILE}.`,
         );
         const cleanedLauncher = cleanupVisibleClientLauncher(launch);
         appendDaemonLog(
-          `visible_client_connect_timeout: adapter=${adapter} cwd=${this.cwd} timeout_ms=${VISIBLE_CLIENT_CONNECT_TIMEOUT_MS} cleaned_launcher=${cleanedLauncher}`,
+          `visible_client_connect_timeout: adapter=${slotKey} cwd=${slotCwd} timeout_ms=${VISIBLE_CLIENT_CONNECT_TIMEOUT_MS} cleaned_launcher=${cleanedLauncher}`,
         );
       }
     }
 
     const activated = options.openVisible === false || visibleConnected;
     if (activated) {
-      this.activeAdapter = adapter;
+      this.activeSlotKey = slotKey;
     }
 
     appendDaemonLog(
-      `switch_adapter: adapter=${adapter} created=${created} opened_visible=${openedVisible} visible_connected=${visibleConnected} activated=${activated} previous_active=${previousActiveAdapter ?? "(none)"} session_start_mode=${sessionStartMode}`,
+      `switch_adapter: adapter=${slotKey} created=${created} opened_visible=${openedVisible} visible_connected=${visibleConnected} activated=${activated} previous_active=${previousActiveAdapter ?? "(none)"} session_start_mode=${sessionStartMode}`,
     );
     return {
       activeAdapter: adapter,
+      activeSlotKey: slotKey,
       created,
       openedVisible,
       visibleConnected,
@@ -1092,19 +1124,20 @@ class WechatDaemon {
 
   private async createSlot(
     adapter: DaemonAdapterKind,
-    options: { profile?: string; sessionStartMode?: BridgeSessionStartMode },
+    options: { cwd: string; instance?: number; profile?: string; sessionStartMode?: BridgeSessionStartMode },
   ): Promise<DaemonSlot> {
-    clearLocalCompanionEndpoint(this.cwd, undefined, { adapter });
+    clearLocalCompanionEndpoint(options.cwd, undefined, { adapter });
     const runtime = createRuntimeHost({
       kind: adapter,
       command: resolveDefaultAdapterCommand(adapter),
-      cwd: this.cwd,
+      cwd: options.cwd,
+      instance: options.instance,
       profile: options.profile,
       lifecycle: "persistent",
       sessionStartMode: options.sessionStartMode,
       companionLaunchMode: "daemon_auto",
     });
-    const controller = new BridgeController(runtime, this.cwd);
+    const controller = new BridgeController(runtime, options.cwd);
     const slot: DaemonSlot = {
       adapter,
       runtime,
@@ -1127,7 +1160,7 @@ class WechatDaemon {
     await runtime.start();
     controller.syncLocalClientEndpoint();
     appendDaemonLog(
-      `slot_started: adapter=${adapter} command=${resolveDefaultAdapterCommand(adapter)} cwd=${this.cwd} session_start_mode=${options.sessionStartMode ?? "restore"}`,
+      `slot_started: adapter=${adapter} command=${resolveDefaultAdapterCommand(adapter)} cwd=${options.cwd} session_start_mode=${options.sessionStartMode ?? "restore"}`,
     );
     return slot;
   }
@@ -1394,7 +1427,8 @@ class WechatDaemon {
     if (emojiMatch) {
       const switchTarget = parseDaemonSwitchCommand(emojiMatch.command);
       if (switchTarget && emojiMatch.remainder) {
-        const result = await this.ensureSlot(switchTarget, {
+        const result = await this.ensureSlot(switchTarget.adapter, {
+          instance: switchTarget.instance,
           openVisible: true,
           reuseExistingVisible: true,
         });
@@ -1402,9 +1436,10 @@ class WechatDaemon {
           message = { ...message, text: emojiMatch.remainder };
         } else {
           const detail = formatDaemonSwitchResultDetail(result);
+          const targetLabel = buildSlotKey(switchTarget.adapter, switchTarget.instance);
           await this.queueWechatMessage(
             message.senderId,
-            `Could not activate terminal: ${switchTarget}.\n${detail}`,
+            `Could not activate terminal: ${targetLabel}.\n${detail}`,
           );
           return;
         }
@@ -1416,16 +1451,18 @@ class WechatDaemon {
       }
     }
 
-    const switchAdapter = parseDaemonSwitchCommand(message.text);
-    if (switchAdapter) {
-      const result = await this.ensureSlot(switchAdapter, {
+    const switchCmd = parseDaemonSwitchCommand(message.text);
+    if (switchCmd) {
+      const result = await this.ensureSlot(switchCmd.adapter, {
+        instance: switchCmd.instance,
         openVisible: true,
         reuseExistingVisible: true,
       });
       const detail = formatDaemonSwitchResultDetail(result);
+      const targetLabel = buildSlotKey(switchCmd.adapter, switchCmd.instance);
       const heading = result.activated
-        ? `Active terminal: ${switchAdapter}.`
-        : `Could not activate terminal: ${switchAdapter}.`;
+        ? `Active terminal: ${targetLabel}.`
+        : `Could not activate terminal: ${targetLabel}.`;
       await this.queueWechatMessage(
         message.senderId,
         `${heading}\n${detail}`,
@@ -1756,10 +1793,28 @@ class WechatDaemon {
   }
 
   private getActiveSlot(): DaemonSlot | null {
-    if (!this.activeAdapter) {
+    if (!this.activeSlotKey) {
       return null;
     }
-    return this.slots.get(this.activeAdapter) ?? null;
+    return this.slots.get(this.activeSlotKey) ?? null;
+  }
+
+  private resolveSlotByAdapter(adapter: DaemonAdapterKind): DaemonSlot | null {
+    // First check the active slot
+    if (this.activeSlotKey) {
+      const slot = this.slots.get(this.activeSlotKey);
+      if (slot && slot.adapter === adapter) return slot;
+    }
+    // Fallback: find any slot matching this adapter kind (prefer bare key)
+    const bareKey = adapter;
+    const bareSlot = this.slots.get(bareKey);
+    if (bareSlot) return bareSlot;
+    // Find first instance-numbered slot for this adapter
+    for (const [key, slot] of this.slots) {
+      const parsed = parseSlotKey(key);
+      if (parsed && parsed.adapter === adapter) return slot;
+    }
+    return null;
   }
 
   private async dispatchInboundWechatText(
@@ -2176,13 +2231,14 @@ async function waitForProcessExit(params: {
 
 function clearSingleBridgeLock(lock: BridgeLockPayload): void {
   try {
-    const current = readBridgeLockFile();
+    const lockFile = getBridgeLockFile(lock.instance);
+    const current = readBridgeLockFile(lock.instance);
     if (
       !current ||
       current.pid === lock.pid ||
       current.instanceId === lock.instanceId
     ) {
-      fs.rmSync(BRIDGE_LOCK_FILE, { force: true });
+      fs.rmSync(lockFile, { force: true });
     }
   } catch {
     // Best effort cleanup.

--- a/src/runtime/runtime-types.ts
+++ b/src/runtime/runtime-types.ts
@@ -14,6 +14,7 @@ export type LocalClientEndpoint = {
   runtimeKind: RuntimeKind;
   instanceId: string;
   kind: "codex" | "claude" | "opencode" | "shell";
+  instance?: number;
   port: number;
   token: string;
   renderMode?: RuntimeRenderMode;

--- a/src/wechat/channel-config.ts
+++ b/src/wechat/channel-config.ts
@@ -59,6 +59,13 @@ export function appendBoundedLog(filePath: string, line: string): void {
   fs.appendFileSync(filePath, line);
 }
 export const BRIDGE_LOCK_FILE = path.join(CHANNEL_DATA_DIR, "bridge.lock.json");
+
+export function getBridgeLockFile(instance?: number): string {
+  if (instance !== undefined && instance > 0) {
+    return path.join(CHANNEL_DATA_DIR, `bridge.lock.claude@${instance}.json`);
+  }
+  return BRIDGE_LOCK_FILE;
+}
 export const DAEMON_ENDPOINT_FILE = path.join(CHANNEL_DATA_DIR, "daemon-endpoint.json");
 export const CODEX_PANEL_ENDPOINT_FILE = path.join(
   CHANNEL_DATA_DIR,
@@ -215,10 +222,14 @@ export function getWorkspaceChannelPaths(cwd: string): WorkspaceChannelPaths {
 export function getWorkspaceAdapterEndpointFile(
   cwd: string,
   adapter: WorkspaceEndpointAdapter,
+  instance?: number,
 ): string {
+  const suffix = instance !== undefined && instance > 0
+    ? `${adapter}@${instance}-companion-endpoint.json`
+    : `${adapter}-companion-endpoint.json`;
   return path.join(
     getWorkspaceChannelPaths(cwd).workspaceDir,
-    `${adapter}-companion-endpoint.json`,
+    suffix,
   );
 }
 

--- a/src/wechat/wechat-transport.ts
+++ b/src/wechat/wechat-transport.ts
@@ -160,6 +160,8 @@ export type ExtractedInboundWechatMessageContent = {
 type PollMessagesOptions = {
   timeoutMs?: number;
   minCreatedAtMs?: number;
+  /** Return false to skip a raw message before claiming, so another process can claim it. */
+  shouldProcess?: (raw: WeixinMessage) => boolean;
 };
 
 type PollMessagesResult = {
@@ -1340,6 +1342,13 @@ export class WeChatTransport {
         createdAtMs < options.minCreatedAtMs
       ) {
         ignoredBacklogCount += 1;
+        continue;
+      }
+
+      // Instance routing filter: skip messages that should be handled by a
+      // different bridge instance.  Must run BEFORE claiming so the correct
+      // instance can claim the message.
+      if (options.shouldProcess && !options.shouldProcess(rawMessage)) {
         continue;
       }
 


### PR DESCRIPTION
---
  修复总结

  修复问题：windows系统中，通过npm全局安装claude后，claude.cmd所在路径可能存在空格，导致执行wechat-claude-start时，报错“Connected to bridge XXXXXX Claude.cmd 不是内部或外部命令”。（虽然开发者都知道路径尽量不要中文空格特殊符号）

  根因：resolveSpawnTarget 在 Windows 上检测到 .cmd 文件时，会用 wrapWithCmdExe 将命令包装成 cmd.exe /d /s /c
  "路径"。node-pty（ConPTY）底层用 CreateProcess
  构建命令行时，会对含空格的参数再次加引号，导致路径被二次引号包裹（""D:\...\claude.cmd""），cmd.exe
  把带引号的字符串当成文件名，自然找不到。

  修复：新增 unwrapCmdExeForPty 函数，在 AbstractPtyAdapter.start() 中，PTY spawn 之前检测并移除 cmd.exe
  包装，直接用 .cmd 文件路径。node-pty/CreateProcess 原生就能执行 .cmd/.bat 文件，不需要 cmd.exe 中介。

  变动文件：src/bridge/bridge-adapters.core.ts
  - 新增 unwrapCmdExeForPty() 函数（~30 行）
  - AbstractPtyAdapter.start() 中：resolveSpawnTarget(...) →unwrapCmdExeForPty(resolveSpawnTarget(...))

  ---
  
    新增功能总结

    可以使用终端开启多个claudecode实例，在微信端使用一个窗口和多个窗口终端沟通。（个人使用场景原因，未对其他支持终端做多实例，可自行参考实现）
    
    用法例子：
    启动两个（多个）终端：
    wechat-claude-multi-start X --cwd D:\project-A，X=任意非Y数字
    wechat-claude-multi-start Y --cwd D:\project-B，Y=任意非X数字
    
    微信端：
    /claude@X 你是谁？ ----> 收到回复例子：[claude@X]我是xxx
    /claude@Y 你好？ ----> 收到回复例子：[claude@Y]你好