### PR TITLE
fix: support newer OpenCode SDK sync events

### DIFF
--- a/src/bridge/bridge-adapters.opencode.ts
+++ b/src/bridge/bridge-adapters.opencode.ts
@@ -133,7 +133,7 @@ type OpenCodeSdkClient = {
     event(options?: Record<string, unknown>): Promise<{
       stream: AsyncIterable<unknown>;
     }>;
-    syncEvent: {
+    syncEvent?: {
       subscribe(options?: Record<string, unknown>): Promise<{
         stream: AsyncIterable<unknown>;
       }>;
@@ -842,11 +842,18 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
     }
 
     this.sseAbortController = new AbortController();
-    this.sseLoopPromise = Promise.all([
+    const sseLoops: Array<Promise<void>> = [
       this.runSseLoop("event"),
       this.runSseLoop("global-event"),
-      this.runSseLoop("global-sync"),
-    ]).then(() => undefined);
+    ];
+    if (this.hasGlobalSyncEventStream()) {
+      sseLoops.push(this.runSseLoop("global-sync"));
+    } else {
+      this.logDebug(
+        "[opencode-adapter:global-sync] syncEvent stream unavailable; using global-event sync payloads.",
+      );
+    }
+    this.sseLoopPromise = Promise.all(sseLoops).then(() => undefined);
   }
 
   private async runSseLoop(streamName: SdkEventStreamName): Promise<void> {
@@ -888,7 +895,11 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
   private subscribeToSseStream(streamName: SdkEventStreamName): Promise<SdkEventSubscription> {
     const signal = this.sseAbortController?.signal;
     if (streamName === "global-sync") {
-      return this.client!.global.syncEvent.subscribe({ signal });
+      const syncEvent = this.client!.global.syncEvent;
+      if (!syncEvent?.subscribe) {
+        throw new Error("OpenCode SDK global syncEvent stream is unavailable.");
+      }
+      return syncEvent.subscribe({ signal });
     }
     if (streamName === "global-event") {
       return this.client!.global.event({ signal });
@@ -902,17 +913,27 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
     );
   }
 
+  private hasGlobalSyncEventStream(): boolean {
+    return typeof this.client?.global.syncEvent?.subscribe === "function";
+  }
+
   private normalizeSdkEvent(rawEvent: unknown): NormalizedSdkEvent | null {
     if (!isRecord(rawEvent)) {
       return null;
     }
 
     if (typeof rawEvent.type === "string") {
+      if (rawEvent.type === "sync") {
+        return this.normalizeGlobalSyncPayload(rawEvent, rawEvent);
+      }
       return rawEvent as NormalizedSdkEvent;
     }
 
     const payload = rawEvent.payload;
     if (isRecord(payload) && typeof payload.type === "string") {
+      if (payload.type === "sync") {
+        return this.normalizeGlobalSyncPayload(payload, rawEvent);
+      }
       const normalized = { ...payload } as NormalizedSdkEvent;
       if (typeof rawEvent.directory === "string") {
         normalized.directory = rawEvent.directory;
@@ -921,6 +942,22 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
     }
 
     return null;
+  }
+
+  private normalizeGlobalSyncPayload(
+    payload: Record<string, unknown>,
+    envelope: Record<string, unknown>,
+  ): NormalizedSdkEvent | null {
+    const syncEvent = isRecord(payload.syncEvent) ? payload.syncEvent : undefined;
+    if (!syncEvent || typeof syncEvent.type !== "string") {
+      return null;
+    }
+
+    const normalized = { ...syncEvent } as NormalizedSdkEvent;
+    if (typeof envelope.directory === "string") {
+      normalized.directory = envelope.directory;
+    }
+    return normalized;
   }
 
   private shouldHandleSseEvent(

--- a/test/bridge/bridge-adapters.opencode.test.ts
+++ b/test/bridge/bridge-adapters.opencode.test.ts
@@ -432,7 +432,7 @@ describe("OpenCode SSE event dispatch", () => {
     expect(events).toHaveLength(0);
   });
 
-  test("starts both local and global sync SSE loops", async () => {
+  test("starts local, global, and legacy global sync SSE loops", async () => {
     const adapter = new OpenCodeServerAdapter({
       kind: "opencode",
       command: "opencode",
@@ -449,7 +449,7 @@ describe("OpenCode SSE event dispatch", () => {
 
     internal.client = {
       event: {},
-      global: { syncEvent: {} },
+      global: { syncEvent: { subscribe: async () => ({ stream: [] }) } },
     };
     internal.runSseLoop = async (streamName: string) => {
       subscribedStreams.push(streamName);
@@ -459,6 +459,35 @@ describe("OpenCode SSE event dispatch", () => {
     await internal.sseLoopPromise;
 
     expect(subscribedStreams).toEqual(["event", "global-event", "global-sync"]);
+  });
+
+  test("skips the legacy global sync SSE loop when the SDK no longer exposes it", async () => {
+    const adapter = new OpenCodeServerAdapter({
+      kind: "opencode",
+      command: "opencode",
+      cwd: process.cwd(),
+    });
+    const internal = adapter as unknown as {
+      client: Record<string, unknown> | null;
+      sseLoopPromise: Promise<void> | null;
+      shuttingDown: boolean;
+      startSseListener(): void;
+      runSseLoop(streamName: string): Promise<void>;
+    };
+    const subscribedStreams: string[] = [];
+
+    internal.client = {
+      event: {},
+      global: {},
+    };
+    internal.runSseLoop = async (streamName: string) => {
+      subscribedStreams.push(streamName);
+    };
+
+    internal.startSseListener();
+    await internal.sseLoopPromise;
+
+    expect(subscribedStreams).toEqual(["event", "global-event"]);
   });
 });
 
@@ -2259,6 +2288,57 @@ describe("OpenCode local TUI tracking", () => {
         reason: "local_follow",
       }),
     ]);
+  });
+
+  test("normalizes newer global sync payloads carried by the global event stream", () => {
+    const adapter = new OpenCodeServerAdapter({
+      kind: "opencode",
+      command: "opencode",
+      cwd: process.cwd(),
+    });
+    const internal = adapter as unknown as {
+      normalizeSdkEvent(
+        event: unknown,
+      ): { type: string; properties?: unknown; data?: unknown; directory?: string } | null;
+      shouldHandleSseEvent(
+        event: { type: string; properties?: unknown; data?: unknown; directory?: string },
+        streamName: string,
+      ): boolean;
+    };
+
+    const syncEvent = internal.normalizeSdkEvent({
+      directory: process.cwd(),
+      payload: {
+        type: "sync",
+        id: "global_event_1",
+        syncEvent: {
+          type: "session.updated.1",
+          id: "sync_event_1",
+          seq: 1,
+          aggregateID: "session_newer_global_sync",
+          data: {
+            sessionID: "session_newer_global_sync",
+            info: {
+              id: "session_newer_global_sync",
+              directory: process.cwd(),
+            },
+          },
+        },
+      },
+    });
+
+    expect(syncEvent).toMatchObject({
+      type: "session.updated.1",
+      directory: process.cwd(),
+      data: {
+        sessionID: "session_newer_global_sync",
+        info: {
+          id: "session_newer_global_sync",
+          directory: process.cwd(),
+        },
+      },
+    });
+    expect(internal.shouldHandleSseEvent(syncEvent!, "global-event")).toBe(true);
   });
 
   test("ignores payload-wrapped global sync session updates from another directory", () => {


### PR DESCRIPTION
This fixes compatibility with newer @opencode-ai/sdk versions where global.syncEvent is no longer exposed as a separate SSE client.

Changes:
- Detect whether global.syncEvent.subscribe exists before starting the legacy global-sync loop.
- Continue using the legacy global-sync loop for older SDK versions.
- Normalize newer global.event sync payloads into the existing session event shape.
- Add regression coverage for both old and new SDK shapes.