### PR TITLE
fix: 在windows中，Claude命令行安装路径包含空格导致的claude.cmd不是内部或外部命令问题

### DIFF
--- a/src/bridge/bridge-adapters.core.ts
+++ b/src/bridge/bridge-adapters.core.ts
@@ -1,4 +1,5 @@
 ﻿import net from "node:net";
+import path from "node:path";
 import { spawn as spawnPty } from "node-pty";
 import type { IPty } from "node-pty";
 import { t } from "../i18n/index.ts";
@@ -49,6 +50,43 @@ const {
   resolveSpawnTarget,
   spawnFallbackProcess,
 } = shared;
+
+/**
+ * On Windows, node-pty (ConPTY) uses CreateProcess which can execute .cmd/.bat
+ * files directly — no need for the cmd.exe wrapper that resolveSpawnTarget adds
+ * for child_process.spawn compatibility.  The wrapper causes double-quoting when
+ * the script path contains spaces: node-pty quotes the already-quoted path,
+ * making cmd.exe treat the literal quotes as part of the filename.
+ */
+function unwrapCmdExeForPty(rawTarget: SpawnTarget): SpawnTarget {
+  if (process.platform !== "win32") {
+    return rawTarget;
+  }
+
+  const fileName = path.basename(rawTarget.file).toLowerCase();
+  if (fileName !== "cmd.exe") {
+    return rawTarget;
+  }
+
+  const args = rawTarget.args;
+  if (args.length < 4 || args[0] !== "/d" || args[1] !== "/s" || args[2] !== "/c") {
+    return rawTarget;
+  }
+
+  // Strip surrounding double-quotes from the /c argument to recover the
+  // actual script path.  quoteForCmd wraps paths containing spaces in
+  // double-quotes, so we reverse that here.
+  const commandLine = args[3] ?? "";
+  const actualScript = commandLine.replace(/^"(.*)"$/s, "$1");
+
+  // Remaining args beyond the /c handler (args[4..]) are extra arguments
+  // that were passed through wrapWithCmdExe; forward them as the new target's
+  // args so they stay prepended before buildSpawnArgs().
+  return {
+    file: actualScript,
+    args: args.slice(4),
+  };
+}
 
 export class LocalCompanionProxyAdapter implements BridgeAdapter {
   private readonly options: AdapterOptions;
@@ -690,7 +728,8 @@ export abstract class AbstractPtyAdapter implements BridgeAdapter {
 
     let spawnTarget: SpawnTarget | null = null;
     try {
-      spawnTarget = resolveSpawnTarget(this.options.command, this.options.kind);
+      const rawTarget = resolveSpawnTarget(this.options.command, this.options.kind);
+      spawnTarget = unwrapCmdExeForPty(rawTarget);
       const env = this.buildEnv();
       const spawnArgs = [...spawnTarget.args, ...this.buildSpawnArgs()];
 


### PR DESCRIPTION
<!--
Bilingual PR template — write English first, then 中文.
Keep one PR focused on one clear problem. Full rules: CONTRIBUTING.md.
双语 PR 模板——先英文,再中文。一个 PR 解决一个清晰问题。完整规范见 CONTRIBUTING.md。
-->

## Summary · 概述

<!-- English: one or two sentences on what this PR changes. -->
**Fix the issue where claude.cmd is not recognized as an internal or external command on Windows due to spaces in the Claude CLI installation path.**

<!-- 中文:同一件事的简短说明。 -->
**修复在 Windows 中，因 Claude 命令行安装路径包含空格而导致 claude.cmd 不被识别为内部或外部命令的问题。**

**Related issue · 关联 issue(可选):** #

## Checklist · 自查

- [√] 本地跑过测试(如 `bun test test`、`npm run lint`)，测试命令：node --no-warnings --experimental-strip-types src/companion/local-companion-start.ts --adapter claude
- [√ ] commit 首行是 Conventional Commit(`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `build:` / `chore:`)


** Details · 详细说明

根因：resolveSpawnTarget 在 Windows 上检测到 .cmd 文件时，会用 wrapWithCmdExe 将命令包装成 cmd.exe /d /s /c "路径"。node-pty（ConPTY）底层用 CreateProcess 构建命令行时，会对含空格的参数再次加引号，导致路径被二次引号包裹（""D:\...\claude.cmd""），cmd.exe
  把带引号的字符串当成文件名，自然找不到。
修复：新增 unwrapCmdExeForPty 函数，在 AbstractPtyAdapter.start() 中，PTY spawn 之前检测并移除 cmd.exe 包装，直接用 .cmd 文件路径。node-pty/CreateProcess 原生就能执行 .cmd/.bat 文件，不需要 cmd.exe 中介。


<!--
涉及运行行为变化时,commit body 请用双语(英文段 + 中文段),与项目 git-log 风格一致——见 CONTRIBUTING.md。
-->
