### PR TITLE
fix: retry health probe to survive serve startup race

### DIFF
--- a/src/bridge/bridge-adapters.opencode.ts
+++ b/src/bridge/bridge-adapters.opencode.ts
@@ -8,6 +8,9 @@ import {
   OPENCODE_SSE_RECONNECT_DELAY_MS,
   OPENCODE_SESSION_IDLE_SETTLE_MS,
   OPENCODE_WECHAT_WORKING_NOTICE_DELAY_MS,
+  OPENCODE_HTTP_READY_TIMEOUT_MS,
+  OPENCODE_HTTP_READY_PROBE_TIMEOUT_MS,
+  OPENCODE_HTTP_READY_PROBE_INTERVAL_MS,
   buildCliEnvironment,
   isRecord,
   describeUnknownError,
@@ -716,10 +719,31 @@ export class OpenCodeServerAdapter implements BridgeAdapter {
 
   private async checkHealth(): Promise<void> {
     const baseUrl = `http://${OPENCODE_SERVER_HOST}:${this.serverPort}`;
-    const response = await fetch(`${baseUrl}/session/status`);
-    if (!response.ok) {
-      throw new Error(`OpenCode health check failed (HTTP ${response.status}).`);
+    // `opencode serve` binds its TCP port before the HTTP layer is ready,
+    // so a fetch fired the instant `waitForTcpPort` returns can be accepted
+    // into the listen backlog but never answered, hanging until undici's
+    // ~300s `headersTimeout` and surfacing as `fetch failed` after ~5min.
+    // Retry with a short per-attempt timeout so the startup race
+    // self-heals once the server finishes booting.
+    const deadline = Date.now() + OPENCODE_HTTP_READY_TIMEOUT_MS;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(`${baseUrl}/session/status`, {
+          signal: AbortSignal.timeout(OPENCODE_HTTP_READY_PROBE_TIMEOUT_MS),
+        });
+        if (response.ok) {
+          return;
+        }
+        lastError = new Error(
+          `OpenCode health check failed (HTTP ${response.status}).`,
+        );
+      } catch (err) {
+        lastError = err;
+      }
+      await delay(OPENCODE_HTTP_READY_PROBE_INTERVAL_MS);
     }
+    throw lastError ?? new Error("OpenCode health check timed out.");
   }
 
   private async initializeSessions(): Promise<void> {

--- a/src/bridge/bridge-adapters.shared.ts
+++ b/src/bridge/bridge-adapters.shared.ts
@@ -181,6 +181,12 @@ export const OPENCODE_SERVER_READY_TIMEOUT_MS = 10_000;
 export const OPENCODE_SSE_RECONNECT_DELAY_MS = 2_000;
 export const OPENCODE_SESSION_IDLE_SETTLE_MS = 1_500;
 export const OPENCODE_WECHAT_WORKING_NOTICE_DELAY_MS = 12_000;
+// `opencode serve` binds its TCP port before the HTTP layer is ready. The
+// health probe therefore retries within this total budget so the startup
+// race self-heals instead of hanging until undici's ~300s headersTimeout.
+export const OPENCODE_HTTP_READY_TIMEOUT_MS = 15_000;
+export const OPENCODE_HTTP_READY_PROBE_TIMEOUT_MS = 3_000;
+export const OPENCODE_HTTP_READY_PROBE_INTERVAL_MS = 500;
 
 export type ShellRuntimeFamily = "powershell" | "posix";
 


### PR DESCRIPTION
opencode serve binds its TCP port before its HTTP layer is ready, so the single-shot checkHealth fetch could be accepted into the listen backlog and hang until undici's ~300s headersTimeout, surfacing as "Failed to start OpenCode: fetch failed" after ~5min. Retry within a 15s budget with a 3s per-attempt timeout so the startup race self-heals once the server finishes booting.

<!--
Bilingual PR template — write English first, then 中文.
Keep one PR focused on one clear problem. Full rules: CONTRIBUTING.md.
双语 PR 模板——先英文,再中文。一个 PR 解决一个清晰问题。完整规范见 CONTRIBUTING.md。
-->

## Summary · 概述

<!-- English: one or two sentences on what this PR changes. -->
**EN:**

<!-- 中文:同一件事的简短说明。 -->
**中文:**

`wechat-opencode-start` 会间歇性卡在 `Starting bridge in background...`，约 5 分钟后后台 bridge 报 `Failed to start OpenCode: fetch failed` 退出，前台因 endpoint 永不就绪而无限挂起。

## Root Cause

`opencode serve` **先绑 TCP 端口、后初始化 HTTP 层**，存在「端口已通、HTTP 不应答」的启动空窗。而 `OpenCodeServerAdapter.checkHealth()` 是单次 `fetch('/session/status')`、无超时无重试：

```js
this.serverPort = await reserveLocalPort();
await this.startServerProcess();            // opencode serve --port P --hostname 127.0.0.1
await waitForTcpPort(HOST, port, 10_000);   // 只检 TCP，端口一绑就返回
await this.checkHealth();                   // 单次 fetch，踩进空窗即挂死
```

`waitForTcpPort` 在端口 listen 的瞬间就返回，此时 fetch 的连接被 listen backlog 接走但永远没有响应，一直挂到 undici 默认 `headersTimeout`（~300s）才以 `fetch failed` 抛出

复现（spawn `opencode serve`、TCP 一通就 fetch）：

```
[serve:out] opencode server listening on http://127.0.0.1:40631
fetch FAIL after 15 s : The operation was aborted due to timeout   # 踩进空窗：挂住
```


### Fix

给 `checkHealth()` 加**短超时 + 重试**，让空窗自动自愈：

- 每次 fetch 带 `AbortSignal.timeout(3_000)`，踩进空窗最多 3s 中止（而非 5 分钟）；
- 失败后 500ms 重试，总预算 15s，覆盖 `opencode serve` 的 HTTP 预热；
- 兼顾原语义：HTTP 非 2xx 仍按失败重试（避免误判 5xx 为就绪）。

新增三个常量在 `bridge-adapters.shared.ts`（`OPENCODE_HTTP_READY_TIMEOUT_MS` / `_PROBE_TIMEOUT_MS` / `_PROBE_INTERVAL_MS`），就近放在既有 `OPENCODE_*` 常量旁。


## Notes

- 这是**间歇性竞态**，非必现，但实测命中概率不低。
- 仓库内同类单次 `fetch`（如 SSE 连接前的探测）可能也有此问题，建议后续一并核对；本 PR 只修 `checkHealth`，保持改动聚焦。
- 改动仅限 2 个源码文件，无运行时状态/依赖变更。



**Related issue · 关联 issue(可选):** #

## Checklist · 自查

- [x] 本地跑过测试(如 `bun test test`、`npm run lint`)

- `npm run typecheck:src` ✅
- `npm run lint`（全量 `eslint bin src test`）✅
- `bun test test`（全量，451 pass / 0 fail / 1179 expect，22 文件，8.5s）✅
- 实测打补丁到全局安装目录后，重跑 `wechat-opencode-start`，companion 正常进入 `idle`，微信↔本地双向同步恢复。

- [x] commit 首行是 Conventional Commit(`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `build:` / `chore:`) 是


<!--
涉及运行行为变化时,commit body 请用双语(英文段 + 中文段),与项目 git-log 风格一致——见 CONTRIBUTING.md。
-->
